### PR TITLE
Fix agent_browser session lifecycle, redaction, and docs drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,9 @@ Dedicated `pi` integration of `agent-browser` as a native tool.
 - Do **not** overengineer or solve hypothetical problems that do not exist in observed behavior.
 - Thoroughly check official `pi` docs/examples/source behavior before inventing bespoke integration patterns. Prefer an official `pi` mechanism whenever one exists.
 - Prioritize the global install path first. Most users will install this extension globally, not as a project-local extension.
+- For this repository, assume a single operator model: no human and no other agent is making changes here besides you.
+- Do **not** use subagents for this repository.
+- Treat every lingering scratch file, temp artifact, browser session, tmux session, or other side effect related to this repository as your responsibility to clean up.
 
 ## Documentation placement
 
@@ -34,7 +37,7 @@ Use an end-to-end interactive `pi` run inside `tmux`.
 - Use `tmux` via bash commands.
 - Do **not** use the pi interactive shell extension for this workflow.
 - Drive `pi` like a real user by sending prompts normally.
-- When testing against other isolated `pi` sessions, feel free to ask those agents for candid feedback on the tool UX and behavior, including whether it feels clunky, uninformative, or slower without clear gain.
+- Do **not** delegate testing or review to other agents or isolated `pi` sessions for this repository.
 - After extension changes, `/reload` is the minimum, but a full close-and-relaunch of `pi` is preferred for higher confidence.
 - If continuing the same conversation after restart, use `/resume` or an explicit session path/id.
 - Resumed sessions should reflect the updated extension code after restart.
@@ -44,6 +47,7 @@ Use an end-to-end interactive `pi` run inside `tmux`.
 - Prefer `tmux send-keys ... Enter` for prompt submission.
 - Capture larger pane ranges when debugging: `tmux capture-pane -p -S -300 -t <session>:0.0`.
 - Clean up tmux sessions after testing.
+- Before ending a turn, sweep for and remove repo-local scratch files, project-scoped temp artifacts, and lingering browser sessions created during the work unless the user explicitly asked to keep them.
 - Do not overfit testing to `example.com`; use it for smoke checks only, then validate against additional realistic pages and flows.
 
 ## Current testing focus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - plain-text inspection commands like `agent_browser --help` and `--version` are now always allowed, removing the old prompt-dependent inspection gate and making the inspection contract local and predictable
 - navigation actions like `click`, `dblclick`, `back`, `forward`, and `reload` now include lightweight post-action title/url summaries when the wrapper can address the active session, reducing guess-and-check follow-up snapshots
 - compact snapshot rendering is leaner by default: fewer additional sections, fewer refs, smaller role summaries, and the raw spill path now stays in `details.fullOutputPath` instead of dominating the visible snapshot body
-- README and injected tool guidance now include a compact agent quick start with the core call shapes for `open` + `snapshot`, `click` + re-snapshot, `batch`, `eval --stdin`, and fresh profiled launches
+- README and tool prompt guidance now include a compact agent quick start with the core call shapes for `open` + `snapshot`, `click` + re-snapshot, `batch`, `eval --stdin`, and fresh profiled launches, while turn-level system-prompt injection stays minimal
 
 ### Migration notes
 - replace any use of `useActiveSession` with `sessionMode`
@@ -29,7 +29,7 @@
 ### Changed
 - hardened the implicit browser-session lifecycle so failed first launches no longer mark the convenience session active, startup-scoped flags behave correctly across launches and closes, and the highest-risk entrypoint paths now have direct automated and isolated-`pi` coverage
 - added explicit temp-root ownership markers, aggregate spill-file disk budgeting, inline image size limits, and graceful fallback behavior when large snapshot or stdout artifacts exceed temp budgets
-- consolidated the shared browser operating playbook across the injected system prompt and tool prompt guidance while adding direct extension-hook coverage for prompt injection, bash blocking, and session resets
+- consolidated the shared browser operating playbook into the tool prompt guidance while keeping turn-level system-prompt injection minimal, and added direct extension-hook coverage for prompt injection, bash blocking, and session resets
 - split the old result-rendering god module into focused envelope, presentation, shared, and snapshot modules, and made snapshot compaction fall back to a resilient outline mode when upstream raw snapshot formatting is unfamiliar
 - refactored the release-package verification script into smaller testable helpers, preserved the retired autoload-shim guard, and aligned the tarball gate with the split result-rendering module layout
 

--- a/README.md
+++ b/README.md
@@ -181,16 +181,17 @@ Validated workflow examples:
 - run `batch` with JSON via `stdin`
 - run `eval --stdin`
 - take a screenshot with inline attachment support
-- inspect `agent_browser --help` and `--version` via the tool's plain-text inspection fallback
+- inspect `agent_browser --help` and `--version` via the tool's stateless plain-text inspection fallback
 
-Inspection commands like `agent_browser --help` and `--version` are always supported. They return plain text and are useful for debugging or capability checks, but they are not required for normal browsing workflows.
+Inspection commands like `agent_browser --help` and `--version` are always supported. They return plain text, are useful for debugging or capability checks, and stay stateless: the extension does not inject its implicit session for them and they do not consume the managed-session slot needed for a later `--profile`, `--session-name`, or `--cdp` launch.
 
 Current cautions:
 - passing `--profile` is an explicit upstream choice; this extension does not add its own profile-cloning or isolation layer
 - startup-scoped flags like `--profile`, `--session-name`, and `--cdp` are for the first command that launches a session; if the implicit session is already active, retry that call with `sessionMode: "fresh"` or provide an explicit `--session ...` for the new launch
-- implicit `piab-*` sessions are extension-managed convenience sessions; they are best-effort closed on `pi` shutdown, get an idle timeout to reduce stale background daemons, and clean up private temp spill artifacts on shutdown
+- implicit `piab-*` sessions are extension-managed convenience sessions; they are best-effort closed on `pi` shutdown, get an idle timeout to reduce stale background daemons, clean up private temp spill artifacts on shutdown, and are reconstructed from persisted tool details on resume/reload so later default calls keep following the active managed browser
 - `sessionMode: "fresh"` without an explicit `--session` rotates that extension-managed session to the new browser so later auto calls keep using it
 - explicit caller-provided `--session` values are treated as user-managed and are not auto-closed by the extension
+- tool progress/details redact sensitive invocation values such as `--headers`, proxy credentials, and auth-bearing URL parameters before echoing them back into Pi
 
 ### Switching from public browsing to a fresh profile/debug launch
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,6 +84,7 @@ Practical policy:
 - on normal `pi` shutdown, best-effort close the current extension-managed session
 - also set an idle timeout on extension-managed sessions so abandoned daemons self-clean after inactivity
 - clean up private temp spill artifacts owned by the extension-managed session on shutdown
+- reconstruct the current extension-managed session from persisted tool details on resume/reload so later default calls keep following the active managed browser
 - if an unnamed fresh launch replaces an active extension-managed session, best-effort close the old managed session after the switch succeeds
 - leave explicit caller-provided `--session` choices alone unless the caller closes them explicitly
 

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -84,7 +84,7 @@ The design should comfortably support workflows such as:
 - web research
 - using browser UIs for other LLMs such as ChatGPT, Grok, Gemini, and Claude
 - isolated authenticated browser sessions
-- cloned-profile workflows similar to the patterns used in `pi-oracle`
+- upstream profile/debug workflows without adding a local profile-cloning layer in this package
 
 ## Implications for the implementation
 

--- a/docs/TOOL_CONTRACT.md
+++ b/docs/TOOL_CONTRACT.md
@@ -121,7 +121,8 @@ Recommended details:
 ```json
 {
   "args": ["snapshot", "-i"],
-  "effectiveArgs": ["--session", "pi-abc123", "--json", "snapshot", "-i"],
+  "effectiveArgs": ["--json", "--session", "pi-abc123", "snapshot", "-i"],
+  "command": "snapshot",
   "sessionMode": "auto",
   "sessionName": "pi-abc123",
   "usedImplicitSession": true,
@@ -131,9 +132,20 @@ Recommended details:
       "e1": { "name": "Example Domain", "role": "heading" }
     },
     "snapshot": "- heading \"Example Domain\" [level=1, ref=e1]"
-  }
+  },
+  "summary": "Snapshot: 1 refs on https://example.com/"
 }
 ```
+
+Additional structured fields can appear when relevant:
+- `batchFailure` and `batchSteps` for `batch` rendering, including mixed-success runs
+- `navigationSummary` for navigation-style commands like `click`, `back`, `forward`, and `reload`
+- `imagePath` / `imagePaths` for screenshots and batched image outputs
+- `fullOutputPath` / `fullOutputPaths` when large snapshot output is compacted and spilled to a private temp file
+- `sessionRecoveryHint` when startup-scoped flags need `sessionMode: "fresh"`
+- `inspection: true` plus `stdout` for successful plain-text inspection commands like `--help` and `--version`
+
+When the tool echoes `args` or `effectiveArgs` back into Pi, sensitive values such as `--headers`, proxy credentials, and auth-bearing URL parameters should be redacted first.
 
 For oversized snapshots, details should switch to a compact metadata object and include `fullOutputPath` pointing at a private temp JSON spill file with the full upstream snapshot payload.
 
@@ -164,10 +176,12 @@ If `agent-browser` is not on `PATH`, fail with a message that:
 - on normal `pi` shutdown, best-effort close the current extension-managed session
 - set an idle timeout on extension-managed sessions so abandoned daemons eventually self-clean
 - clean up private temp spill artifacts owned by the extension-managed session on shutdown
+- reconstruct the current extension-managed session from persisted tool details on resume/reload so later default calls keep following the active managed browser
 - when an unnamed `sessionMode: "fresh"` launch succeeds, make it the new extension-managed session so later default calls keep using it
 - if that unnamed fresh launch replaced an already-active managed session, best-effort close the old managed session after the switch succeeds
 - treat explicit caller-provided `--session` choices as user-managed
 - pass explicit `--profile` straight through to upstream `agent-browser`; no profile-cloning or isolation layer is added in v1
+- treat successful plain-text inspection commands like `--help` and `--version` as stateless: do not inject the implicit managed session and do not let those calls claim the managed-session slot
 - if startup-scoped flags like `--profile`, `--session-name`, or `--cdp` are supplied after the implicit session is already active while `sessionMode` is `"auto"`, return a validation error with a structured recovery hint that recommends `sessionMode: "fresh"`
 
 ## Non-goals

--- a/extensions/agent-browser/index.ts
+++ b/extensions/agent-browser/index.ts
@@ -24,6 +24,8 @@ import {
 	getLatestUserPrompt,
 	hasUsableBraveApiKey,
 	redactInvocationArgs,
+	redactSensitiveText,
+	redactSensitiveValue,
 	restoreManagedSessionStateFromBranch,
 	resolveManagedSessionState,
 	shouldAppendBrowserSystemPrompt,
@@ -458,19 +460,22 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 							envelope: presentationEnvelope,
 							errorText,
 					  });
+				const redactedContent = presentation.content.map((item) =>
+					item.type === "text" ? { ...item, text: redactSensitiveText(item.text) } : item,
+				);
 
 				return {
-					content: presentation.content,
+					content: redactedContent,
 					details: {
 						args: redactedArgs,
-						batchFailure: presentation.batchFailure,
-						batchSteps: presentation.batchSteps,
+						batchFailure: redactSensitiveValue(presentation.batchFailure),
+						batchSteps: redactSensitiveValue(presentation.batchSteps),
 						command: executionPlan.commandInfo.command,
 						subcommand: executionPlan.commandInfo.subcommand,
-						data: presentation.data,
-						error: plainTextInspection ? undefined : parsed.envelope?.error,
+						data: redactSensitiveValue(presentation.data),
+						error: plainTextInspection ? undefined : redactSensitiveValue(parsed.envelope?.error),
 						inspection: plainTextInspection || undefined,
-						navigationSummary,
+						navigationSummary: redactSensitiveValue(navigationSummary),
 						effectiveArgs: redactedEffectiveArgs,
 						exitCode: processResult.exitCode,
 						fullOutputPath: presentation.fullOutputPath,
@@ -482,9 +487,13 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 						...buildSessionDetailFields(executionPlan.sessionName, executionPlan.usedImplicitSession),
 						sessionRecoveryHint: redactedRecoveryHint,
 						startupScopedFlags: executionPlan.startupScopedFlags,
-						stderr: processResult.stderr || undefined,
-						stdout: plainTextInspection ? inspectionText : parseSucceeded ? undefined : processResult.stdout,
-						summary: presentation.summary,
+						stderr: processResult.stderr ? redactSensitiveText(processResult.stderr) : undefined,
+						stdout: plainTextInspection
+							? redactSensitiveText(inspectionText ?? "")
+							: parseSucceeded
+								? undefined
+								: redactSensitiveText(processResult.stdout),
+						summary: redactSensitiveText(presentation.summary),
 					},
 					isError: !succeeded,
 				};

--- a/extensions/agent-browser/index.ts
+++ b/extensions/agent-browser/index.ts
@@ -23,7 +23,10 @@ import {
 	getImplicitSessionIdleTimeoutMs,
 	getLatestUserPrompt,
 	hasUsableBraveApiKey,
+	redactInvocationArgs,
+	restoreManagedSessionStateFromBranch,
 	resolveManagedSessionState,
+	shouldAppendBrowserSystemPrompt,
 	validateToolArgs,
 } from "./lib/runtime.js";
 import { cleanupSecureTempArtifacts } from "./lib/temp.js";
@@ -104,10 +107,6 @@ function looksLikeDirectAgentBrowserBash(command: string): boolean {
 
 function isHarmlessAgentBrowserInspectionCommand(command: string): boolean {
 	return HARMLESS_AGENT_BROWSER_INSPECTION_PATTERN.test(command);
-}
-
-function isPlainTextInspectionArgs(args: string[]): boolean {
-	return args.includes("--help") || args.includes("-h") || args.includes("--version") || args.includes("-V");
 }
 
 const NAVIGATION_SUMMARY_COMMANDS = new Set(["back", "click", "dblclick", "forward", "reload"]);
@@ -195,18 +194,6 @@ function buildSharedBrowserPlaybookGuidelines(hasBraveApiKey: boolean): string[]
 	];
 }
 
-function buildBrowserSystemPromptAppendix(hasBraveApiKey: boolean): string {
-	return [
-		PROJECT_RULE_PROMPT,
-		"",
-		"Quick start:",
-		...QUICK_START_GUIDELINES.map((guideline) => `- ${guideline}`),
-		"",
-		"Browser operating playbook:",
-		...buildSharedBrowserPlaybookGuidelines(hasBraveApiKey).map((guideline) => `- ${guideline}`),
-	].join("\n");
-}
-
 function buildToolPromptGuidelines(hasBraveApiKey: boolean): string[] {
 	return [
 		...TOOL_PROMPT_GUIDELINES_PREFIX,
@@ -214,6 +201,30 @@ function buildToolPromptGuidelines(hasBraveApiKey: boolean): string[] {
 		...buildSharedBrowserPlaybookGuidelines(hasBraveApiKey),
 		...TOOL_PROMPT_GUIDELINES_SUFFIX,
 	];
+}
+
+function buildSessionDetailFields(sessionName: string | undefined, usedImplicitSession: boolean): Record<string, unknown> {
+	return sessionName ? { sessionName, usedImplicitSession } : {};
+}
+
+function redactRecoveryHint(recoveryHint: {
+	exampleArgs: string[];
+	exampleParams: { args: string[]; sessionMode: "fresh" };
+	reason: string;
+	recommendedSessionMode: "fresh";
+} | undefined): typeof recoveryHint {
+	if (!recoveryHint) {
+		return undefined;
+	}
+	const exampleArgs = redactInvocationArgs(recoveryHint.exampleArgs);
+	return {
+		...recoveryHint,
+		exampleArgs,
+		exampleParams: {
+			...recoveryHint.exampleParams,
+			args: exampleArgs,
+		},
+	};
 }
 
 async function closeManagedSession(options: { cwd: string; sessionName: string; timeoutMs: number }): Promise<void> {
@@ -235,7 +246,6 @@ async function closeManagedSession(options: { cwd: string; sessionName: string; 
 export default function agentBrowserExtension(pi: ExtensionAPI) {
 	const ephemeralSessionSeed = createEphemeralSessionSeed();
 	const hasBraveApiKey = hasUsableBraveApiKey();
-	const browserSystemPromptAppendix = buildBrowserSystemPromptAppendix(hasBraveApiKey);
 	const toolPromptGuidelines = buildToolPromptGuidelines(hasBraveApiKey);
 	const implicitSessionIdleTimeoutMs = getImplicitSessionIdleTimeoutMs();
 	const implicitSessionCloseTimeoutMs = getImplicitSessionCloseTimeoutMs();
@@ -246,26 +256,32 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 	let freshSessionOrdinal = 0;
 
 	pi.on("session_start", async (_event, ctx) => {
-		managedSessionActive = false;
 		managedSessionBaseName = createImplicitSessionName(ctx.sessionManager.getSessionId(), ctx.cwd, ephemeralSessionSeed);
-		managedSessionName = managedSessionBaseName;
+		const restoredState = restoreManagedSessionStateFromBranch(ctx.sessionManager.getBranch(), managedSessionBaseName);
+		managedSessionActive = restoredState.active;
+		managedSessionName = restoredState.sessionName;
 		managedSessionCwd = ctx.cwd;
-		freshSessionOrdinal = 0;
+		freshSessionOrdinal = restoredState.freshSessionOrdinal;
 	});
 
 	pi.on("session_shutdown", async () => {
+		if (managedSessionActive) {
+			await closeManagedSession({
+				cwd: managedSessionCwd,
+				sessionName: managedSessionName,
+				timeoutMs: implicitSessionCloseTimeoutMs,
+			});
+		}
 		managedSessionActive = false;
-		await closeManagedSession({
-			cwd: managedSessionCwd,
-			sessionName: managedSessionName,
-			timeoutMs: implicitSessionCloseTimeoutMs,
-		});
 		await cleanupSecureTempArtifacts();
 	});
 
 	pi.on("before_agent_start", async (event) => {
+		if (!shouldAppendBrowserSystemPrompt(event.prompt)) {
+			return undefined;
+		}
 		return {
-			systemPrompt: `${event.systemPrompt}\n\n${browserSystemPromptAppendix}`,
+			systemPrompt: `${event.systemPrompt}\n\n${PROJECT_RULE_PROMPT}`,
 		};
 	});
 
@@ -294,11 +310,12 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 		promptGuidelines: toolPromptGuidelines,
 		parameters: AGENT_BROWSER_PARAMS,
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
+			const redactedArgs = redactInvocationArgs(params.args);
 			const validationError = validateToolArgs(params.args);
 			if (validationError) {
 				return {
 					content: [{ type: "text", text: validationError }],
-					details: { args: params.args, validationError },
+					details: { args: redactedArgs, validationError },
 					isError: true,
 				};
 			}
@@ -311,6 +328,8 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 				managedSessionName,
 				sessionMode,
 			});
+			const redactedEffectiveArgs = redactInvocationArgs(executionPlan.effectiveArgs);
+			const redactedRecoveryHint = redactRecoveryHint(executionPlan.recoveryHint);
 			if (executionPlan.managedSessionName === freshSessionName) {
 				freshSessionOrdinal += 1;
 			}
@@ -319,10 +338,10 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 				return {
 					content: [{ type: "text", text: executionPlan.validationError }],
 					details: {
-						args: params.args,
+						args: redactedArgs,
 						invalidValueFlag: executionPlan.invalidValueFlag,
 						sessionMode,
-						sessionRecoveryHint: executionPlan.recoveryHint,
+						sessionRecoveryHint: redactedRecoveryHint,
 						startupScopedFlags: executionPlan.startupScopedFlags,
 						validationError: executionPlan.validationError,
 					},
@@ -331,12 +350,11 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 			}
 
 			onUpdate?.({
-				content: [{ type: "text", text: `Running agent-browser ${buildInvocationPreview(executionPlan.effectiveArgs)}` }],
+				content: [{ type: "text", text: `Running agent-browser ${buildInvocationPreview(redactedEffectiveArgs)}` }],
 				details: {
-					effectiveArgs: executionPlan.effectiveArgs,
+					effectiveArgs: redactedEffectiveArgs,
 					sessionMode,
-					sessionName: executionPlan.sessionName,
-					usedImplicitSession: executionPlan.usedImplicitSession,
+					...buildSessionDetailFields(executionPlan.sessionName, executionPlan.usedImplicitSession),
 				},
 			});
 
@@ -353,8 +371,8 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 				return {
 					content: [{ type: "text", text: errorText }],
 					details: {
-						args: params.args,
-						effectiveArgs: executionPlan.effectiveArgs,
+						args: redactedArgs,
+						effectiveArgs: redactedEffectiveArgs,
 						sessionMode,
 						spawnError: processResult.spawnError.message,
 					},
@@ -369,10 +387,11 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 				});
 				let presentationEnvelope = parsed.envelope;
 				const processSucceeded = !processResult.aborted && !processResult.spawnError && processResult.exitCode === 0;
-				const plainTextInspection = isPlainTextInspectionArgs(params.args) && processSucceeded && parsed.parseError !== undefined;
-				const envelopeSuccess = plainTextInspection ? true : parsed.envelope?.success !== false;
+				const plainTextInspection = executionPlan.plainTextInspection && processSucceeded;
 				const parseSucceeded = plainTextInspection || parsed.parseError === undefined;
+				const envelopeSuccess = plainTextInspection ? true : parsed.envelope?.success !== false;
 				const succeeded = processSucceeded && parseSucceeded && envelopeSuccess;
+				const inspectionText = plainTextInspection ? processResult.stdout.trim() : undefined;
 
 				let navigationSummary: NavigationSummary | undefined;
 				if (succeeded && shouldCaptureNavigationSummary(executionPlan.commandInfo.command, parsed.envelope?.data)) {
@@ -423,9 +442,15 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 
 				const presentation = plainTextInspection
 					? {
-						content: [{ type: "text" as const, text: processResult.stdout.trim() }],
+						batchFailure: undefined,
+						batchSteps: undefined,
+						content: [{ type: "text" as const, text: inspectionText ?? "" }],
+						data: undefined,
+						fullOutputPath: undefined,
+						fullOutputPaths: undefined,
 						imagePath: undefined,
-						summary: `${params.args.join(" ")} completed`,
+						imagePaths: undefined,
+						summary: `${redactedArgs.join(" ")} completed`,
 					  }
 					: await buildToolPresentation({
 							commandInfo: executionPlan.commandInfo,
@@ -437,29 +462,29 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 				return {
 					content: presentation.content,
 					details: {
-						args: params.args,
+						args: redactedArgs,
 						batchFailure: presentation.batchFailure,
 						batchSteps: presentation.batchSteps,
 						command: executionPlan.commandInfo.command,
 						subcommand: executionPlan.commandInfo.subcommand,
 						data: presentation.data,
-						error: parsed.envelope?.error,
+						error: plainTextInspection ? undefined : parsed.envelope?.error,
+						inspection: plainTextInspection || undefined,
 						navigationSummary,
-						effectiveArgs: executionPlan.effectiveArgs,
+						effectiveArgs: redactedEffectiveArgs,
 						exitCode: processResult.exitCode,
 						fullOutputPath: presentation.fullOutputPath,
 						fullOutputPaths: presentation.fullOutputPaths,
 						imagePath: presentation.imagePath,
 						imagePaths: presentation.imagePaths,
-						parseError: parsed.parseError,
+						parseError: plainTextInspection ? undefined : parsed.parseError,
 						sessionMode,
-						sessionName: executionPlan.sessionName,
-						sessionRecoveryHint: executionPlan.recoveryHint,
+						...buildSessionDetailFields(executionPlan.sessionName, executionPlan.usedImplicitSession),
+						sessionRecoveryHint: redactedRecoveryHint,
 						startupScopedFlags: executionPlan.startupScopedFlags,
 						stderr: processResult.stderr || undefined,
-						stdout: parseSucceeded ? undefined : processResult.stdout,
+						stdout: plainTextInspection ? inspectionText : parseSucceeded ? undefined : processResult.stdout,
 						summary: presentation.summary,
-						usedImplicitSession: executionPlan.usedImplicitSession,
 					},
 					isError: !succeeded,
 				};

--- a/extensions/agent-browser/lib/process.ts
+++ b/extensions/agent-browser/lib/process.ts
@@ -65,7 +65,7 @@ const INHERITED_ENV_NAMES = new Set([
 	allProxyEnvName,
 	noProxyEnvName,
 ]);
-const INHERITED_ENV_PREFIXES = ["AGENT_BROWSER_", "AI_GATEWAY_", "XDG_"] as const;
+const INHERITED_ENV_PREFIXES = ["AI_GATEWAY_", "XDG_"] as const;
 
 export interface ProcessRunResult {
 	aborted: boolean;

--- a/extensions/agent-browser/lib/runtime.ts
+++ b/extensions/agent-browser/lib/runtime.ts
@@ -1,9 +1,9 @@
 /**
- * Purpose: Build safe, deterministic agent-browser invocations for the pi-agent-browser extension.
- * Responsibilities: Validate raw tool arguments, derive extension-managed session names from the pi session identity, resolve managed-session timeout/state helpers, detect explicit session usage, and build the effective CLI argument list passed to the upstream agent-browser binary.
+ * Purpose: Build safe, deterministic agent-browser invocations and persisted session state for the pi-agent-browser extension.
+ * Responsibilities: Validate raw tool arguments, derive extension-managed session names from the pi session identity, restore managed-session state from persisted tool details, redact sensitive invocation text, classify browser-oriented prompts, and build the effective CLI argument list passed to the upstream agent-browser binary.
  * Scope: Pure runtime-planning helpers only; no subprocess execution or filesystem access lives here.
  * Usage: Imported by the extension entrypoint and unit tests before spawning the upstream CLI.
- * Invariants/Assumptions: The wrapper stays thin, preserves upstream command vocabulary, and only injects `--json` plus an extension-managed `--session` when appropriate.
+ * Invariants/Assumptions: The wrapper stays thin, preserves upstream command vocabulary, keeps plain-text inspection stateless, and only injects `--json` plus an extension-managed `--session` when appropriate.
  */
 
 import { createHash, randomUUID } from "node:crypto";
@@ -23,6 +23,14 @@ const LEGACY_BASH_ALLOW_PATTERNS = [
 	/\bagent-browser\s+--(?:help|version)\b/i,
 	/\bdebug(?:ging)?\b.*\b(?:agent[_ -]?browser|agent_browser|browser integration)\b/i,
 ];
+const BROWSER_PROMPT_PATTERNS = [
+	/https?:\/\/\S+/i,
+	/\b(?:agent[_ -]?browser|browser automation|browser|browse|click|dashboard|eval\s+--stdin|feed|fill|form|inbox|login|navigate|navigation|open|page|screenshot|site|snapshot|tab\s+list|timeline|url|web(?:site| page)?)\b/i,
+];
+const INSPECTION_FLAGS = new Set(["--help", "-h", "--version", "-V"]);
+const SENSITIVE_VALUE_FLAGS = new Set(["--headers", "--proxy"]);
+const SENSITIVE_QUERY_PARAM_PATTERN =
+	/^(?:access(?:_|-)token|api(?:_|-)key|auth|authorization|bearer|client(?:_|-)secret|code|cookie|id(?:_|-)token|key|pass(?:word)?|refresh(?:_|-)token|secret|session(?:_|-)id|sig(?:nature)?|token)$/i;
 
 const GLOBAL_FLAGS_WITH_VALUES = new Set([
 	"--session",
@@ -78,6 +86,7 @@ export interface ExecutionPlan {
 	effectiveArgs: string[];
 	invalidValueFlag?: InvalidValueFlagDetails;
 	managedSessionName?: string;
+	plainTextInspection: boolean;
 	recoveryHint?: SessionRecoveryHint;
 	sessionName?: string;
 	startupScopedFlags: string[];
@@ -91,8 +100,114 @@ export interface ManagedSessionState {
 	sessionName: string;
 }
 
+export interface RestoredManagedSessionState extends ManagedSessionState {
+	freshSessionOrdinal: number;
+}
+
 export interface PromptPolicy {
 	allowLegacyAgentBrowserBash: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function shouldRedactQueryParam(name: string): boolean {
+	return SENSITIVE_QUERY_PARAM_PATTERN.test(name);
+}
+
+function redactUrlToken(token: string): string {
+	let parsed: URL;
+	try {
+		parsed = new URL(token);
+	} catch {
+		return token;
+	}
+
+	if (!["http:", "https:", "ws:", "wss:"].includes(parsed.protocol)) {
+		return token;
+	}
+
+	if (parsed.username.length > 0) {
+		parsed.username = "[REDACTED]";
+	}
+	if (parsed.password.length > 0) {
+		parsed.password = "[REDACTED]";
+	}
+
+	for (const [name] of parsed.searchParams) {
+		if (shouldRedactQueryParam(name)) {
+			parsed.searchParams.set(name, "[REDACTED]");
+		}
+	}
+
+	const hashText = parsed.hash.startsWith("#") ? parsed.hash.slice(1) : parsed.hash;
+	if (hashText.includes("=")) {
+		const hashParams = new URLSearchParams(hashText);
+		let mutated = false;
+		for (const [name] of hashParams) {
+			if (shouldRedactQueryParam(name)) {
+				hashParams.set(name, "[REDACTED]");
+				mutated = true;
+			}
+		}
+		if (mutated) {
+			parsed.hash = `#${hashParams.toString()}`;
+		}
+	}
+
+	return parsed.toString();
+}
+
+function redactFlagValue(flag: string, value: string): string {
+	if (SENSITIVE_VALUE_FLAGS.has(flag)) {
+		return "[REDACTED]";
+	}
+	return redactUrlToken(value);
+}
+
+export function redactInvocationArgs(args: string[]): string[] {
+	const redacted: string[] = [];
+	let pendingValueFlag: string | undefined;
+
+	for (const token of args) {
+		if (pendingValueFlag) {
+			redacted.push(redactFlagValue(pendingValueFlag, token));
+			pendingValueFlag = undefined;
+			continue;
+		}
+
+		const normalizedToken = token.split("=", 1)[0] ?? token;
+		if (SENSITIVE_VALUE_FLAGS.has(normalizedToken)) {
+			if (token.includes("=")) {
+				redacted.push(`${normalizedToken}=[REDACTED]`);
+			} else {
+				redacted.push(token);
+				pendingValueFlag = normalizedToken;
+			}
+			continue;
+		}
+
+		redacted.push(redactUrlToken(token));
+	}
+
+	return redacted;
+}
+
+export function shouldAppendBrowserSystemPrompt(prompt: string): boolean {
+	const normalizedPrompt = prompt.trim();
+	if (normalizedPrompt.length === 0) {
+		return false;
+	}
+	return BROWSER_PROMPT_PATTERNS.some((pattern) => pattern.test(normalizedPrompt));
+}
+
+export function isPlainTextInspectionArgs(args: string[]): boolean {
+	return args.some((token) => INSPECTION_FLAGS.has(token));
 }
 
 export function hasUsableBraveApiKey(apiKey: string | null | undefined = process.env[BRAVE_API_KEY_ENV]): boolean {
@@ -143,6 +258,64 @@ export function resolveManagedSessionState(options: {
 		active: true,
 		replacedSessionName: priorActive && priorSessionName !== managedSessionName ? priorSessionName : undefined,
 		sessionName: managedSessionName,
+	};
+}
+
+export function restoreManagedSessionStateFromBranch(
+	branch: unknown[],
+	fallbackSessionName: string,
+): RestoredManagedSessionState {
+	let restoredState: ManagedSessionState = {
+		active: false,
+		sessionName: fallbackSessionName,
+	};
+	let freshSessionOrdinal = 0;
+
+	for (const entry of branch) {
+		if (!isRecord(entry) || entry.type !== "message") {
+			continue;
+		}
+		const message = isRecord(entry.message) ? entry.message : undefined;
+		if (!message || message.toolName !== "agent_browser") {
+			continue;
+		}
+		const details = isRecord(message.details) ? message.details : undefined;
+		if (!details) {
+			continue;
+		}
+		const args = isStringArray(details.args) ? details.args : [];
+		if (isPlainTextInspectionArgs(args)) {
+			continue;
+		}
+
+		const explicitSessionName = extractExplicitSessionName(args);
+		const sessionName = typeof details.sessionName === "string" ? details.sessionName : undefined;
+		const sessionMode = details.sessionMode === "fresh" || details.sessionMode === "auto" ? details.sessionMode : undefined;
+		const usedImplicitSession = details.usedImplicitSession === true;
+		const managedSessionName = !explicitSessionName && sessionName && (usedImplicitSession || sessionMode === "fresh") ? sessionName : undefined;
+		if (!managedSessionName) {
+			continue;
+		}
+
+		const messageIsError = typeof message.isError === "boolean" ? message.isError : undefined;
+		const exitCode = typeof details.exitCode === "number" ? details.exitCode : undefined;
+		const succeeded = messageIsError === undefined ? exitCode === undefined || exitCode === 0 : !messageIsError;
+		const command = typeof details.command === "string" ? details.command : parseCommandInfo(args).command;
+		restoredState = resolveManagedSessionState({
+			command,
+			managedSessionName,
+			priorActive: restoredState.active,
+			priorSessionName: restoredState.sessionName,
+			succeeded,
+		});
+		if (succeeded && sessionMode === "fresh") {
+			freshSessionOrdinal += 1;
+		}
+	}
+
+	return {
+		...restoredState,
+		freshSessionOrdinal,
 	};
 }
 
@@ -310,22 +483,34 @@ export function buildExecutionPlan(
 		sessionMode: SessionMode;
 	},
 ): ExecutionPlan {
-	const effectiveArgs = args.includes("--json") ? [] : ["--json"];
 	const invalidValueFlag = getInvalidValueFlagDetails(args);
+	const startupScopedFlags = getStartupScopedFlags(args);
+	const plainTextInspection = isPlainTextInspectionArgs(args);
+	const commandInfo = parseCommandInfo(args);
+	const effectiveArgs = plainTextInspection ? [...args] : args.includes("--json") ? [] : ["--json"];
 	if (invalidValueFlag) {
 		return {
 			commandInfo: {},
 			effectiveArgs,
 			invalidValueFlag,
+			plainTextInspection: false,
 			startupScopedFlags: [],
 			usedImplicitSession: false,
 			validationError: formatInvalidValueFlagError(invalidValueFlag),
 		};
 	}
 
-	const commandInfo = parseCommandInfo(args);
+	if (plainTextInspection) {
+		return {
+			commandInfo,
+			effectiveArgs,
+			plainTextInspection,
+			startupScopedFlags,
+			usedImplicitSession: false,
+		};
+	}
+
 	const explicitSessionName = extractExplicitSessionName(args);
-	const startupScopedFlags = getStartupScopedFlags(args);
 	const shouldCreateFreshManagedSession =
 		!explicitSessionName && options.sessionMode === "fresh" && commandInfo.command !== undefined && commandInfo.command !== "close";
 	let managedSessionName: string | undefined;
@@ -365,6 +550,7 @@ export function buildExecutionPlan(
 		commandInfo,
 		effectiveArgs,
 		managedSessionName,
+		plainTextInspection,
 		recoveryHint,
 		sessionName,
 		startupScopedFlags,
@@ -396,4 +582,3 @@ export function parseCommandInfo(args: string[]): CommandInfo {
 
 	return { command: commands[0], subcommand: commands[1] };
 }
-

--- a/extensions/agent-browser/lib/runtime.ts
+++ b/extensions/agent-browser/lib/runtime.ts
@@ -24,13 +24,16 @@ const LEGACY_BASH_ALLOW_PATTERNS = [
 	/\bdebug(?:ging)?\b.*\b(?:agent[_ -]?browser|agent_browser|browser integration)\b/i,
 ];
 const BROWSER_PROMPT_PATTERNS = [
-	/https?:\/\/\S+/i,
-	/\b(?:agent[_ -]?browser|browser automation|browser|browse|click|dashboard|eval\s+--stdin|feed|fill|form|inbox|login|navigate|navigation|open|page|screenshot|site|snapshot|tab\s+list|timeline|url|web(?:site| page)?)\b/i,
+	/\b(?:agent[_ -]?browser|browser automation|eval\s+--stdin|screenshot|snapshot|tab\s+list)\b/i,
+	/\bbrowser\b.*\b(?:automation|click|fill|navigate|open|page|screenshot|site|snapshot|tab|url|visit|web(?:site| page)?)\b/i,
+	/\b(?:browse|click|fill|login|navigate|open|visit)\b.*\b(?:https?:\/\/\S+|page|site|tab|url|web(?:site| page)?)\b/i,
 ];
 const INSPECTION_FLAGS = new Set(["--help", "-h", "--version", "-V"]);
 const SENSITIVE_VALUE_FLAGS = new Set(["--headers", "--proxy"]);
 const SENSITIVE_QUERY_PARAM_PATTERN =
-	/^(?:access(?:_|-)token|api(?:_|-)key|auth|authorization|bearer|client(?:_|-)secret|code|cookie|id(?:_|-)token|key|pass(?:word)?|refresh(?:_|-)token|secret|session(?:_|-)id|sig(?:nature)?|token)$/i;
+	/^(?:access(?:_|-)?token|api(?:_|-)?key|auth|authorization|bearer|client(?:_|-)?secret|code|cookie|id(?:_|-)?token|key|pass(?:word)?|refresh(?:_|-)?token|secret|session(?:_|-)?id|sig(?:nature)?|token)$/i;
+const SENSITIVE_FIELD_NAME_PATTERN =
+	/^(?:access(?:_|-)?token|api(?:_|-)?key|auth(?:orization)?|bearer|client(?:_|-)?secret|cookie|id(?:_|-)?token|pass(?:word)?|proxy(?:_|-)?authorization|refresh(?:_|-)?token|secret|session(?:_|-)?id|set(?:_|-)?cookie|sig(?:nature)?|token|x(?:_|-)?api(?:_|-)?key)$/i;
 
 const GLOBAL_FLAGS_WITH_VALUES = new Set([
 	"--session",
@@ -163,6 +166,36 @@ function redactUrlToken(token: string): string {
 	return parsed.toString();
 }
 
+function redactLooseUrlMatches(text: string): string {
+	return text.replace(/\b(?:https?|wss?):\/\/[^\s"'`<>\])]+/g, (match) => redactUrlToken(match));
+}
+
+export function redactSensitiveText(text: string): string {
+	return redactLooseUrlMatches(text)
+		.replace(/\b(Bearer)\s+[^\s",]+/gi, "$1 [REDACTED]")
+		.replace(/\b(Basic)\s+[^\s",]+/gi, "$1 [REDACTED]");
+}
+
+export function redactSensitiveValue(value: unknown): unknown {
+	if (typeof value === "string") {
+		return redactSensitiveText(value);
+	}
+	if (Array.isArray(value)) {
+		return value.map((item) => redactSensitiveValue(item));
+	}
+	if (!isRecord(value)) {
+		return value;
+	}
+	return Object.fromEntries(
+		Object.entries(value).map(([key, entryValue]) => {
+			if (SENSITIVE_FIELD_NAME_PATTERN.test(key)) {
+				return [key, "[REDACTED]"];
+			}
+			return [key, redactSensitiveValue(entryValue)];
+		}),
+	);
+}
+
 function redactFlagValue(flag: string, value: string): string {
 	if (SENSITIVE_VALUE_FLAGS.has(flag)) {
 		return "[REDACTED]";
@@ -261,6 +294,10 @@ export function resolveManagedSessionState(options: {
 	};
 }
 
+function isRestorableManagedSessionName(sessionName: string, fallbackSessionName: string): boolean {
+	return sessionName === fallbackSessionName || sessionName.startsWith(`${fallbackSessionName}-fresh-`);
+}
+
 export function restoreManagedSessionStateFromBranch(
 	branch: unknown[],
 	fallbackSessionName: string,
@@ -292,7 +329,13 @@ export function restoreManagedSessionStateFromBranch(
 		const sessionName = typeof details.sessionName === "string" ? details.sessionName : undefined;
 		const sessionMode = details.sessionMode === "fresh" || details.sessionMode === "auto" ? details.sessionMode : undefined;
 		const usedImplicitSession = details.usedImplicitSession === true;
-		const managedSessionName = !explicitSessionName && sessionName && (usedImplicitSession || sessionMode === "fresh") ? sessionName : undefined;
+		const managedSessionName =
+			!explicitSessionName &&
+			sessionName &&
+			isRestorableManagedSessionName(sessionName, fallbackSessionName) &&
+			(usedImplicitSession || sessionMode === "fresh")
+				? sessionName
+				: undefined;
 		if (!managedSessionName) {
 			continue;
 		}

--- a/test/agent-browser.test.ts
+++ b/test/agent-browser.test.ts
@@ -36,7 +36,10 @@ import {
 	getLatestUserPrompt,
 	hasUsableBraveApiKey,
 	parseCommandInfo,
+	redactInvocationArgs,
+	restoreManagedSessionStateFromBranch,
 	resolveManagedSessionState,
+	shouldAppendBrowserSystemPrompt,
 } from "../extensions/agent-browser/lib/runtime.js";
 
 const TEST_SESSION_ID = "12345678-1234-5678-9abc-def012345678";
@@ -47,7 +50,18 @@ function buildUserBranch(prompt = ""): unknown[] {
 		: [{ type: "message", message: { role: "user", content: [{ type: "text", text: prompt }] } }];
 }
 
-function createExtensionHarness(options: { cwd: string; prompt?: string }) {
+function createToolBranchEntry(options: { details: Record<string, unknown>; isError?: boolean }): unknown {
+	return {
+		type: "message",
+		message: {
+			isError: options.isError,
+			details: options.details,
+			toolName: "agent_browser",
+		},
+	};
+}
+
+function createExtensionHarness(options: { branch?: unknown[]; cwd: string; prompt?: string }) {
 	const handlers = new Map<string, Array<(...args: unknown[]) => unknown>>();
 	let registeredTool:
 		| {
@@ -78,10 +92,11 @@ function createExtensionHarness(options: { cwd: string; prompt?: string }) {
 
 	assert.ok(registeredTool, "expected the extension to register the agent_browser tool");
 
+	const branch = options.branch ?? buildUserBranch(options.prompt);
 	const ctx = {
 		cwd: options.cwd,
 		sessionManager: {
-			getBranch: () => buildUserBranch(options.prompt),
+			getBranch: () => branch,
 			getSessionId: () => TEST_SESSION_ID,
 		},
 	} as const;
@@ -258,6 +273,60 @@ test("resolveManagedSessionState only adopts successful managed sessions and ide
 	);
 });
 
+test("restoreManagedSessionStateFromBranch ignores inspection entries and reconstructs the latest managed session", () => {
+	const restored = restoreManagedSessionStateFromBranch(
+		[
+			createToolBranchEntry({
+				details: {
+					args: ["--version"],
+					exitCode: 0,
+					sessionMode: "auto",
+					sessionName: "piab-demo-123",
+					usedImplicitSession: true,
+				},
+			}),
+			createToolBranchEntry({
+				details: {
+					args: ["open", "https://example.com"],
+					command: "open",
+					exitCode: 0,
+					sessionMode: "auto",
+					sessionName: "piab-demo-123",
+					usedImplicitSession: true,
+				},
+			}),
+			createToolBranchEntry({
+				details: {
+					args: ["--profile", "Default", "open", "https://example.com/profile"],
+					command: "open",
+					exitCode: 0,
+					sessionMode: "fresh",
+					sessionName: "piab-demo-123-fresh-aaa",
+					usedImplicitSession: false,
+				},
+			}),
+			createToolBranchEntry({
+				details: {
+					args: ["snapshot", "-i"],
+					command: "snapshot",
+					exitCode: 0,
+					sessionMode: "auto",
+					sessionName: "piab-demo-123-fresh-aaa",
+					usedImplicitSession: true,
+				},
+			}),
+		],
+		"piab-demo-123",
+	);
+
+	assert.deepEqual(restored, {
+		active: true,
+		freshSessionOrdinal: 1,
+		replacedSessionName: undefined,
+		sessionName: "piab-demo-123-fresh-aaa",
+	});
+});
+
 test("secure temp cleanup can recreate and track a later temp root", { concurrency: false }, async () => {
 	await cleanupSecureTempArtifacts();
 
@@ -348,6 +417,22 @@ test("buildExecutionPlan respects explicit upstream sessions", () => {
 	assert.equal(plan.managedSessionName, undefined);
 	assert.equal(plan.sessionName, "custom");
 	assert.equal(plan.usedImplicitSession, false);
+});
+
+test("buildExecutionPlan keeps inspection commands stateless", () => {
+	const plan = buildExecutionPlan(["--version"], {
+		freshSessionName: createFreshSessionName("piab-demo-123", "seed", 1),
+		managedSessionActive: true,
+		managedSessionName: "piab-demo-123",
+		sessionMode: "auto",
+	});
+
+	assert.equal(plan.plainTextInspection, true);
+	assert.deepEqual(plan.effectiveArgs, ["--version"]);
+	assert.equal(plan.managedSessionName, undefined);
+	assert.equal(plan.sessionName, undefined);
+	assert.equal(plan.usedImplicitSession, false);
+	assert.equal(plan.validationError, undefined);
 });
 
 test("buildExecutionPlan rejects missing values for value-taking flags before parsing commands", () => {
@@ -446,7 +531,26 @@ test("buildPromptPolicy allows explicit tool-specific legacy bash inspection req
 	assert.equal(policy.allowLegacyAgentBrowserBash, true);
 });
 
-test("agentBrowserExtension registers shared browser guidance across hooks and tool metadata", async () => {
+test("redactInvocationArgs masks sensitive flags and auth-bearing urls", () => {
+	assert.deepEqual(redactInvocationArgs(["--headers", '{"Authorization":"Bearer demo"}', "open", "https://user:pass@example.com/path?token=abc&ok=1#access_token=xyz"]), [
+		"--headers",
+		"[REDACTED]",
+		"open",
+		"https://%5BREDACTED%5D:%5BREDACTED%5D@example.com/path?token=%5BREDACTED%5D&ok=1#access_token=%5BREDACTED%5D",
+	]);
+	assert.deepEqual(redactInvocationArgs(["--proxy=http://user:pass@proxy.example:8080", "open", "https://example.com"]), [
+		"--proxy=[REDACTED]",
+		"open",
+		"https://example.com/",
+	]);
+});
+
+test("shouldAppendBrowserSystemPrompt only targets clearly browser-oriented prompts", () => {
+	assert.equal(shouldAppendBrowserSystemPrompt("Open https://example.com and take a snapshot."), true);
+	assert.equal(shouldAppendBrowserSystemPrompt("Please review the repository architecture."), false);
+});
+
+test("agentBrowserExtension keeps the full browser playbook in tool metadata and only injects a minimal browser prompt when relevant", async () => {
 	await withPatchedEnv({ BRAVE_API_KEY: "demo-key" }, async () => {
 		const harness = createExtensionHarness({ cwd: process.cwd() });
 		assert.deepEqual([...harness.handlers.keys()].sort(), ["before_agent_start", "session_shutdown", "session_start", "tool_call"]);
@@ -467,27 +571,26 @@ test("agentBrowserExtension registers shared browser guidance across hooks and t
 		for (const fragment of sharedGuidelineFragments) {
 			assert.equal(harness.tool.promptGuidelines.some((guideline) => guideline.includes(fragment)), true);
 		}
-		assert.equal(
-			harness.tool.promptGuidelines.filter((guideline) => guideline.includes("Do not invent fixed explicit session names")).length,
-			1,
-		);
 
-		const [beforeAgentStart] = await runExtensionEventResults<{ systemPrompt: string }>(
+		const [genericTurn] = await runExtensionEventResults<{ systemPrompt: string }>(
 			harness.handlers,
 			"before_agent_start",
-			{ systemPrompt: "Base system prompt" },
+			{ prompt: "Please review the repository architecture.", systemPrompt: "Base system prompt" },
 			harness.ctx,
 		);
-		assert.equal(typeof beforeAgentStart?.systemPrompt, "string");
-		assert.equal(beforeAgentStart?.systemPrompt.includes("Base system prompt"), true);
-		assert.equal(beforeAgentStart?.systemPrompt.includes("Project rule: when browser automation is needed"), true);
-		assert.equal(beforeAgentStart?.systemPrompt.includes("Quick start:"), true);
-		assert.equal(beforeAgentStart?.systemPrompt.includes("Browser operating playbook:"), true);
-		assert.equal(beforeAgentStart?.systemPrompt.split("Quick start:").length - 1, 1);
-		assert.equal(beforeAgentStart?.systemPrompt.split("Browser operating playbook:").length - 1, 1);
-		for (const fragment of sharedGuidelineFragments) {
-			assert.equal(beforeAgentStart?.systemPrompt.includes(fragment), true);
-		}
+		assert.equal(genericTurn, undefined);
+
+		const [browserTurn] = await runExtensionEventResults<{ systemPrompt: string }>(
+			harness.handlers,
+			"before_agent_start",
+			{ prompt: "Open https://example.com and take a snapshot.", systemPrompt: "Base system prompt" },
+			harness.ctx,
+		);
+		assert.equal(typeof browserTurn?.systemPrompt, "string");
+		assert.equal(browserTurn?.systemPrompt.includes("Base system prompt"), true);
+		assert.equal(browserTurn?.systemPrompt.includes("Project rule: when browser automation is needed"), true);
+		assert.equal(browserTurn?.systemPrompt.includes("Quick start:"), false);
+		assert.equal(browserTurn?.systemPrompt.includes("Browser operating playbook:"), false);
 	});
 });
 
@@ -528,10 +631,17 @@ test("agentBrowserExtension blocks direct and wrapped agent-browser bash unless 
 	assert.deepEqual(debugAllowed, []);
 });
 
-test("agentBrowserExtension allows plain-text inspection commands regardless of prompt wording", { concurrency: false }, async () => {
+test("agentBrowserExtension keeps successful plain-text inspection stateless and machine-readable", { concurrency: false }, async () => {
 	const tempDir = await mkdtemp(join(tmpdir(), "pi-agent-browser-test-"));
+	const logPath = join(tempDir, "invocations.log");
 	const basePath = process.env.PATH ?? "";
-	await writeFakeAgentBrowserBinary(tempDir, `process.stdout.write("agent-browser 9.9.9\\n");`);
+	await writeFakeAgentBrowserBinary(
+		tempDir,
+		`const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ args }) + "\\n");
+process.stdout.write("agent-browser 9.9.9\\n");`,
+	);
 
 	try {
 		await withPatchedEnv({ PATH: `${tempDir}:${basePath}` }, async () => {
@@ -545,7 +655,51 @@ test("agentBrowserExtension allows plain-text inspection commands regardless of 
 			assert.equal(result.isError, false);
 			assert.equal(result.content[0]?.type, "text");
 			assert.match((result.content[0] as { text: string }).text, /agent-browser 9\.9\.9/);
-			assert.equal(result.details?.inspectionBlocked, undefined);
+			assert.equal(result.details?.inspection, true);
+			assert.equal(result.details?.stdout, "agent-browser 9.9.9");
+			assert.equal(result.details?.parseError, undefined);
+			assert.equal(result.details?.sessionName, undefined);
+			assert.equal(result.details?.usedImplicitSession, undefined);
+			assert.deepEqual(await readInvocationLog(logPath), [{ args: ["--version"] }]);
+		});
+	} finally {
+		await rm(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("agentBrowserExtension redacts sensitive args in updates and persisted details", { concurrency: false }, async () => {
+	const tempDir = await mkdtemp(join(tmpdir(), "pi-agent-browser-test-"));
+	const basePath = process.env.PATH ?? "";
+	await writeFakeAgentBrowserBinary(tempDir, `process.stdout.write(JSON.stringify({ success: true, data: { title: "ok" } }));`);
+
+	try {
+		await withPatchedEnv({ PATH: `${tempDir}:${basePath}` }, async () => {
+			const harness = createExtensionHarness({ cwd: tempDir });
+			await runExtensionEvent(harness.handlers, "session_start", { reason: "new" }, harness.ctx);
+
+			const updates: unknown[] = [];
+			const result = (await harness.tool.execute(
+				"test-tool-call",
+				{ args: ["--headers", '{"Authorization":"Bearer s3cr3t-demo"}', "open", "https://user:pass@example.com/?token=abc"] },
+				new AbortController().signal,
+				(update) => updates.push(update),
+				harness.ctx,
+			)) as { details?: Record<string, unknown>; isError?: boolean };
+
+			assert.equal(result.isError, false);
+			assert.equal(Array.isArray(updates), true);
+			const update = updates[0] as { content?: Array<{ text?: string }>; details?: Record<string, unknown> } | undefined;
+			assert.match(update?.content?.[0]?.text ?? "", /\[REDACTED\]/);
+			assert.doesNotMatch(update?.content?.[0]?.text ?? "", /s3cr3t-demo/);
+			assert.doesNotMatch(update?.content?.[0]?.text ?? "", /user:pass/);
+			assert.deepEqual(result.details?.args, [
+				"--headers",
+				"[REDACTED]",
+				"open",
+				"https://%5BREDACTED%5D:%5BREDACTED%5D@example.com/?token=%5BREDACTED%5D",
+			]);
+			assert.equal(JSON.stringify(result.details?.effectiveArgs).includes("s3cr3t-demo"), false);
+			assert.equal(JSON.stringify(result.details?.effectiveArgs).includes("user:pass"), false);
 		});
 	} finally {
 		await rm(tempDir, { force: true, recursive: true });
@@ -1330,7 +1484,7 @@ process.stdout.write(JSON.stringify(envelope));`,
 				};
 				assert.equal(data.secret, null);
 				assert.equal(data.lang, "en_US.UTF-8");
-				assert.equal(data.agentBrowserSession, "from-parent");
+				assert.equal(data.agentBrowserSession, null);
 				assert.equal(data.idleTimeout, "1234");
 				assert.equal(data.pathStartsWithTemp, true);
 			},
@@ -1340,7 +1494,7 @@ process.stdout.write(JSON.stringify(envelope));`,
 	}
 });
 
-test("agentBrowserExtension resets implicit session state on session_start", { concurrency: false }, async () => {
+test("agentBrowserExtension reconstructs managed session state on session_start and keeps startup-scoped flags blocked after resume", { concurrency: false }, async () => {
 	const tempDir = await mkdtemp(join(tmpdir(), "pi-agent-browser-test-"));
 	const logPath = join(tempDir, "invocations.log");
 	const basePath = process.env.PATH ?? "";
@@ -1349,30 +1503,37 @@ test("agentBrowserExtension resets implicit session state on session_start", { c
 		`const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ args }) + "\\n");
-process.stdout.write(JSON.stringify({ success: true, data: { url: args[args.length - 1] } }));`,
+const envelope = args.includes("close")
+  ? { success: true, data: { closed: true } }
+  : { success: true, data: { url: args[args.length - 1] } };
+process.stdout.write(JSON.stringify(envelope));`,
 	);
 
 	try {
 		await withPatchedEnv({ PATH: `${tempDir}:${basePath}` }, async () => {
-			const harness = createExtensionHarness({ cwd: tempDir });
-			await runExtensionEvent(harness.handlers, "session_start", { reason: "new" }, harness.ctx);
+			const firstHarness = createExtensionHarness({ cwd: tempDir });
+			await runExtensionEvent(firstHarness.handlers, "session_start", { reason: "new" }, firstHarness.ctx);
 
-			const firstOpen = await executeRegisteredTool(harness.tool, harness.ctx, {
+			const firstOpen = await executeRegisteredTool(firstHarness.tool, firstHarness.ctx, {
 				args: ["open", "https://example.com/first"],
 			});
 			assert.equal(firstOpen.isError, false);
 
-			await runExtensionEvent(harness.handlers, "session_start", { reason: "resume" }, harness.ctx);
+			const resumedBranch = [
+				createToolBranchEntry({
+					details: firstOpen.details ?? {},
+					isError: firstOpen.isError,
+				}),
+			];
+			const resumedHarness = createExtensionHarness({ branch: resumedBranch, cwd: tempDir });
+			await runExtensionEvent(resumedHarness.handlers, "session_start", { reason: "resume" }, resumedHarness.ctx);
 
-			const profiledOpen = await executeRegisteredTool(harness.tool, harness.ctx, {
+			const blocked = await executeRegisteredTool(resumedHarness.tool, resumedHarness.ctx, {
 				args: ["--profile", "Default", "open", "https://example.com/profiled"],
 			});
-			assert.equal(profiledOpen.isError, false);
-
-			const invocations = await readInvocationLog(logPath);
-			assert.equal(invocations.length, 2);
-			assert.equal(invocations[0]?.args.includes("--session"), true);
-			assert.equal(invocations[1]?.args.includes("--profile"), true);
+			assert.equal(blocked.isError, true);
+			assert.match(String(blocked.details?.validationError ?? ""), /startup-scoped flags/i);
+			assert.equal((await readInvocationLog(logPath)).length, 1);
 		});
 	} finally {
 		await rm(tempDir, { force: true, recursive: true });
@@ -1450,7 +1611,7 @@ process.stdout.write(JSON.stringify(envelope));`,
 	},
 );
 
-test("agentBrowserExtension rotates the managed session to a fresh profile launch and reuses it on follow-up auto calls", { concurrency: false }, async () => {
+test("agentBrowserExtension restores the rotated fresh managed session across resume and reuses it on follow-up auto calls", { concurrency: false }, async () => {
 	const tempDir = await mkdtemp(join(tmpdir(), "pi-agent-browser-test-"));
 	const logPath = join(tempDir, "invocations.log");
 	const basePath = process.env.PATH ?? "";
@@ -1467,17 +1628,17 @@ process.stdout.write(JSON.stringify(envelope));`,
 
 	try {
 		await withPatchedEnv({ PATH: `${tempDir}:${basePath}`, PI_AGENT_BROWSER_IMPLICIT_SESSION_IDLE_TIMEOUT_MS: "1234" }, async () => {
-			const harness = createExtensionHarness({ cwd: tempDir });
-			await runExtensionEvent(harness.handlers, "session_start", { reason: "new" }, harness.ctx);
+			const firstHarness = createExtensionHarness({ cwd: tempDir });
+			await runExtensionEvent(firstHarness.handlers, "session_start", { reason: "new" }, firstHarness.ctx);
 
-			const firstOpen = await executeRegisteredTool(harness.tool, harness.ctx, {
+			const firstOpen = await executeRegisteredTool(firstHarness.tool, firstHarness.ctx, {
 				args: ["open", "https://example.com"],
 			});
 			assert.equal(firstOpen.isError, false);
 			const firstSessionName = firstOpen.details?.sessionName;
 			assert.equal(typeof firstSessionName, "string");
 
-			const profiledOpen = await executeRegisteredTool(harness.tool, harness.ctx, {
+			const profiledOpen = await executeRegisteredTool(firstHarness.tool, firstHarness.ctx, {
 				args: ["--profile", "Default", "open", "https://example.com/profile"],
 				sessionMode: "fresh",
 			});
@@ -1492,7 +1653,16 @@ process.stdout.write(JSON.stringify(envelope));`,
 				true,
 			);
 
-			const followUpSnapshot = await executeRegisteredTool(harness.tool, harness.ctx, {
+			const resumedHarness = createExtensionHarness({
+				branch: [
+					createToolBranchEntry({ details: firstOpen.details ?? {}, isError: firstOpen.isError }),
+					createToolBranchEntry({ details: profiledOpen.details ?? {}, isError: profiledOpen.isError }),
+				],
+				cwd: tempDir,
+			});
+			await runExtensionEvent(resumedHarness.handlers, "session_start", { reason: "resume" }, resumedHarness.ctx);
+
+			const followUpSnapshot = await executeRegisteredTool(resumedHarness.tool, resumedHarness.ctx, {
 				args: ["snapshot", "-i"],
 			});
 			assert.equal(followUpSnapshot.isError, false);

--- a/test/agent-browser.test.ts
+++ b/test/agent-browser.test.ts
@@ -7,7 +7,7 @@
  */
 
 import assert from "node:assert/strict";
-import { chmod, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -37,6 +37,7 @@ import {
 	hasUsableBraveApiKey,
 	parseCommandInfo,
 	redactInvocationArgs,
+	redactSensitiveValue,
 	restoreManagedSessionStateFromBranch,
 	resolveManagedSessionState,
 	shouldAppendBrowserSystemPrompt,
@@ -327,6 +328,30 @@ test("restoreManagedSessionStateFromBranch ignores inspection entries and recons
 	});
 });
 
+test("restoreManagedSessionStateFromBranch keeps cwd isolation by ignoring sessions from a different base name", () => {
+	const restored = restoreManagedSessionStateFromBranch(
+		[
+			createToolBranchEntry({
+				details: {
+					args: ["open", "https://example.com"],
+					command: "open",
+					exitCode: 0,
+					sessionMode: "auto",
+					sessionName: "piab-other-checkout-123456781234-abcd1234",
+					usedImplicitSession: true,
+				},
+			}),
+		],
+		"piab-demo-123",
+	);
+
+	assert.deepEqual(restored, {
+		active: false,
+		freshSessionOrdinal: 0,
+		sessionName: "piab-demo-123",
+	});
+});
+
 test("secure temp cleanup can recreate and track a later temp root", { concurrency: false }, async () => {
 	await cleanupSecureTempArtifacts();
 
@@ -538,6 +563,10 @@ test("redactInvocationArgs masks sensitive flags and auth-bearing urls", () => {
 		"open",
 		"https://%5BREDACTED%5D:%5BREDACTED%5D@example.com/path?token=%5BREDACTED%5D&ok=1#access_token=%5BREDACTED%5D",
 	]);
+	assert.deepEqual(redactInvocationArgs(["open", "https://example.com/path?apiKey=abc&refreshToken=def&ok=1"]), [
+		"open",
+		"https://example.com/path?apiKey=%5BREDACTED%5D&refreshToken=%5BREDACTED%5D&ok=1",
+	]);
 	assert.deepEqual(redactInvocationArgs(["--proxy=http://user:pass@proxy.example:8080", "open", "https://example.com"]), [
 		"--proxy=[REDACTED]",
 		"open",
@@ -545,8 +574,33 @@ test("redactInvocationArgs masks sensitive flags and auth-bearing urls", () => {
 	]);
 });
 
+test("redactSensitiveValue masks obvious secret-bearing object keys", () => {
+	assert.deepEqual(
+		redactSensitiveValue({
+			apiKey: "abc",
+			nested: {
+				authorization: "Bearer demo",
+				ok: "https://example.com/?ok=1&token=abc",
+				"set-cookie": "sid=abc",
+			},
+			status: { code: "ERR_BLOCKED_BY_CLIENT", key: "Enter" },
+		}),
+		{
+			apiKey: "[REDACTED]",
+			nested: {
+				authorization: "[REDACTED]",
+				ok: "https://example.com/?ok=1&token=%5BREDACTED%5D",
+				"set-cookie": "[REDACTED]",
+			},
+			status: { code: "ERR_BLOCKED_BY_CLIENT", key: "Enter" },
+		},
+	);
+});
+
 test("shouldAppendBrowserSystemPrompt only targets clearly browser-oriented prompts", () => {
 	assert.equal(shouldAppendBrowserSystemPrompt("Open https://example.com and take a snapshot."), true);
+	assert.equal(shouldAppendBrowserSystemPrompt("Please review browser compatibility docs."), false);
+	assert.equal(shouldAppendBrowserSystemPrompt("Summarize the article at https://example.com/blog/post for the changelog."), false);
 	assert.equal(shouldAppendBrowserSystemPrompt("Please review the repository architecture."), false);
 });
 
@@ -670,7 +724,10 @@ process.stdout.write("agent-browser 9.9.9\\n");`,
 test("agentBrowserExtension redacts sensitive args in updates and persisted details", { concurrency: false }, async () => {
 	const tempDir = await mkdtemp(join(tmpdir(), "pi-agent-browser-test-"));
 	const basePath = process.env.PATH ?? "";
-	await writeFakeAgentBrowserBinary(tempDir, `process.stdout.write(JSON.stringify({ success: true, data: { title: "ok" } }));`);
+	await writeFakeAgentBrowserBinary(
+		tempDir,
+		`process.stdout.write(JSON.stringify({ success: true, data: { title: "ok", url: "https://user:pass@example.com/?token=abc" } }));`,
+	);
 
 	try {
 		await withPatchedEnv({ PATH: `${tempDir}:${basePath}` }, async () => {
@@ -684,7 +741,7 @@ test("agentBrowserExtension redacts sensitive args in updates and persisted deta
 				new AbortController().signal,
 				(update) => updates.push(update),
 				harness.ctx,
-			)) as { details?: Record<string, unknown>; isError?: boolean };
+			)) as { content: Array<{ type: string; text?: string }>; details?: Record<string, unknown>; isError?: boolean };
 
 			assert.equal(result.isError, false);
 			assert.equal(Array.isArray(updates), true);
@@ -700,6 +757,8 @@ test("agentBrowserExtension redacts sensitive args in updates and persisted deta
 			]);
 			assert.equal(JSON.stringify(result.details?.effectiveArgs).includes("s3cr3t-demo"), false);
 			assert.equal(JSON.stringify(result.details?.effectiveArgs).includes("user:pass"), false);
+			assert.equal(JSON.stringify(result.details?.data).includes("user:pass"), false);
+			assert.equal(JSON.stringify(result.content).includes("user:pass"), false);
 		});
 	} finally {
 		await rm(tempDir, { force: true, recursive: true });
@@ -1282,7 +1341,7 @@ process.exitCode = 1;`,
 			assert.equal(result.content[0]?.type, "text");
 			assert.match((result.content[0] as { text: string }).text, /Batch failed: 1\/2 succeeded/);
 			assert.match((result.content[0] as { text: string }).text, /First failing step: 2 — click @zzz/);
-			assert.match((result.content[0] as { text: string }).text, /Step 1 — open https:\/\/example.com \(succeeded\)/);
+			assert.match((result.content[0] as { text: string }).text, /Step 1 — open https:\/\/example.com\/? \(succeeded\)/);
 			assert.match((result.content[0] as { text: string }).text, /Example Domain/);
 			assert.match((result.content[0] as { text: string }).text, /Step 2 — click @zzz \(failed\)/);
 			assert.match((result.content[0] as { text: string }).text, /Error: Unknown ref: zzz/);
@@ -1537,6 +1596,59 @@ process.stdout.write(JSON.stringify(envelope));`,
 		});
 	} finally {
 		await rm(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("agentBrowserExtension does not restore a managed session from a different cwd/worktree on resume", { concurrency: false }, async () => {
+	const firstParent = await mkdtemp(join(tmpdir(), "pi-agent-browser-first-"));
+	const secondParent = await mkdtemp(join(tmpdir(), "pi-agent-browser-second-"));
+	const firstDir = join(firstParent, "checkout");
+	const secondDir = join(secondParent, "checkout");
+	const binDir = await mkdtemp(join(tmpdir(), "pi-agent-browser-bin-"));
+	const logPath = join(binDir, "invocations.log");
+	const basePath = process.env.PATH ?? "";
+	await mkdir(firstDir, { recursive: true });
+	await mkdir(secondDir, { recursive: true });
+	await writeFakeAgentBrowserBinary(
+		binDir,
+		`const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ args }) + "\\n");
+process.stdout.write(JSON.stringify({ success: true, data: { url: args[args.length - 1] } }));`,
+	);
+
+	try {
+		await withPatchedEnv({ PATH: `${binDir}:${basePath}` }, async () => {
+			const firstHarness = createExtensionHarness({ cwd: firstDir });
+			await runExtensionEvent(firstHarness.handlers, "session_start", { reason: "new" }, firstHarness.ctx);
+			const firstOpen = await executeRegisteredTool(firstHarness.tool, firstHarness.ctx, {
+				args: ["open", "https://example.com/first"],
+			});
+			assert.equal(firstOpen.isError, false);
+			const firstSessionName = firstOpen.details?.sessionName;
+			assert.equal(typeof firstSessionName, "string");
+
+			const resumedHarness = createExtensionHarness({
+				branch: [createToolBranchEntry({ details: firstOpen.details ?? {}, isError: firstOpen.isError })],
+				cwd: secondDir,
+			});
+			await runExtensionEvent(resumedHarness.handlers, "session_start", { reason: "resume" }, resumedHarness.ctx);
+
+			const profiledOpen = await executeRegisteredTool(resumedHarness.tool, resumedHarness.ctx, {
+				args: ["--profile", "Default", "open", "https://example.com/profiled"],
+			});
+			assert.equal(profiledOpen.isError, false);
+			assert.equal((profiledOpen.details?.effectiveArgs as string[] | undefined)?.includes("--profile"), true);
+			assert.notEqual(profiledOpen.details?.sessionName, firstSessionName);
+			const invocations = await readInvocationLog(logPath);
+			assert.equal(invocations.length, 2);
+			assert.equal(invocations[1]?.args.includes("--profile"), true);
+			assert.equal(invocations[1]?.args.includes(String(firstSessionName)), false);
+		});
+	} finally {
+		await rm(firstParent, { force: true, recursive: true });
+		await rm(secondParent, { force: true, recursive: true });
+		await rm(binDir, { force: true, recursive: true });
 	}
 });
 


### PR DESCRIPTION
## Summary
- make plain-text inspection stateless and machine-readable
- restore managed session state across resume/reload and keep fresh-session rotation intact
- redact sensitive args, narrow env forwarding, trim unrelated prompt injection, and sync docs
- add regression coverage for inspection, resume, redaction, and prompt behavior

Closes #1

## Local validation
- `npm run verify:release`
- local `pi --no-extensions -e .` tmux validation for `--version` -> startup-scoped open -> tab recovery -> `snapshot -i`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session lifecycle and tool output/details handling; mistakes could break session reuse/cleanup or leak/redact data incorrectly during browser automation.
> 
> **Overview**
> Fixes the `agent_browser` wrapper to **persist and reconstruct the extension-managed session** across `/resume`/reload by restoring state from prior tool-call details (including keeping fresh-session rotation), and only closes managed sessions on shutdown when one is actually active.
> 
> Makes `--help`/`--version` **stateless inspection calls** (no implicit `--session` injection, don’t consume the managed-session slot) and returns them with explicit `details.inspection`/`stdout` while suppressing parse errors.
> 
> Adds **end-to-end redaction** for sensitive flags/values (e.g. `--headers`, `--proxy`, auth-bearing URLs, Bearer/Basic tokens) across updates, persisted `details` (`args`, `effectiveArgs`, recovery hints, `data`, `stderr/stdout`, summaries) and trims turn-level prompt injection to a minimal rule only when the user prompt looks browser-oriented; also narrows subprocess env forwarding by no longer inheriting `AGENT_BROWSER_*` from the parent and updates docs/tests to match the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08fec57f7a03dd132f9ab3673c3b7346adf24b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->