### PR TITLE
Add agent-browser result categories

### DIFF
--- a/.cueloop/queue.jsonc
+++ b/.cueloop/queue.jsonc
@@ -3,7 +3,7 @@
   "tasks": [
     {
       "id": "RQ-0058",
-      "status": "todo",
+      "status": "doing",
       "title": "Expose stable machine-readable result and failure categories",
       "priority": "high",
       "tags": [
@@ -30,7 +30,8 @@
       "notes": [],
       "request": "Infer and queue the stable failure/result category work from the user's ABN task list.",
       "created_at": "2026-05-13T13:33:42.731677000Z",
-      "updated_at": "2026-05-13T13:40:06.107090000Z",
+      "updated_at": "2026-05-13T15:15:27.787994000Z",
+      "started_at": "2026-05-13T15:15:27.787994000Z",
       "depends_on": [
         "RQ-0057"
       ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,14 @@ Verification stack:
 
 Release-oriented notes also live in [`docs/RELEASE.md`](docs/RELEASE.md) under pre-release and real-upstream sections.
 
+### Tool result categories
+
+`agent_browser` results include stable machine-readable fields on `details`: `resultCategory` (`success` | `failure`), plus `successCategory` or `failureCategory` with small fixed enums. The human-facing contract and field list live in [`docs/TOOL_CONTRACT.md`](docs/TOOL_CONTRACT.md#details).
+
+- **Source of truth for enums and classifiers:** `extensions/agent-browser/lib/results/shared.ts` (`classifyAgentBrowserSuccessCategory`, `classifyAgentBrowserFailureCategory`, `buildAgentBrowserResultCategoryDetails`). The tool entrypoint merges category details in `extensions/agent-browser/index.ts`; presentation-layer failures also attach categories from `extensions/agent-browser/lib/results/presentation.ts`.
+- **Regression tests:** `test/agent-browser.results.test.ts` locks classifier behavior; `test/agent-browser.extension-validation.test.ts` asserts `details` on representative tool outcomes; `test/agent-browser.presentation.test.ts` covers batch and presentation wiring.
+- **When changing categories:** extend the TypeScript unions and classifier in `shared.ts`, update the prose list in `docs/TOOL_CONTRACT.md`, add or adjust tests above, and refresh any benchmark or docs that mention failure-category coverage if the taxonomy changes.
+
 ### Agent browser efficiency benchmark
 
 `scripts/agent-browser-efficiency-benchmark.mjs` is a **deterministic accounting benchmark**: it does not shell out to `agent-browser`, does not launch a browser, and does not read or write Pi sessions. It models representative `agent_browser` call shapes (including optional `stdin` for `batch`) and synthetic model-visible strings to produce comparable totals: scenario success rate, total tool calls, UTF-8 byte volume of model-visible output, stale-ref failure and recovery counts, artifact success count, distinct failure-category coverage, and summed elapsed-time estimates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - documented how `npm run docs` differs from the default `npm run verify` gate, and linked checkout maintainers to `AGENTS.md` for capability baseline rebaselining and operational testing notes alongside the shipped `docs/` set
+- linked [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) to the stable `agent_browser` result-category contract in [`docs/TOOL_CONTRACT.md`](docs/TOOL_CONTRACT.md#details) and the TypeScript source in `extensions/agent-browser/lib/results/shared.ts`
 
 ## 0.2.24 - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- bounded machine-readable outcome fields on native `agent_browser` tool `details`: `resultCategory` (`success` | `failure`) with `successCategory` or `failureCategory` for stable agent branching without parsing prose; contract in [`docs/TOOL_CONTRACT.md`](docs/TOOL_CONTRACT.md#details), types and classifiers in `extensions/agent-browser/lib/results/shared.ts`, regression coverage in `test/agent-browser.results.test.ts` and related extension tests
+
 ### Changed
 - documented how `npm run docs` differs from the default `npm run verify` gate, and linked checkout maintainers to `AGENTS.md` for capability baseline rebaselining and operational testing notes alongside the shipped `docs/` set
 - linked [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) to the stable `agent_browser` result-category contract in [`docs/TOOL_CONTRACT.md`](docs/TOOL_CONTRACT.md#details) and the TypeScript source in `extensions/agent-browser/lib/results/shared.ts`

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The result is optimized for agent work:
 | Profile restores and tab drift confuse agents | Tracks managed sessions, pins intended tabs, and re-selects target tabs after drift | generated tab-recovery notes below; `test/agent-browser.resume-state.test.ts` |
 | Auth/profile workflows can leak secrets | Supports `auth save --password-stdin` and redacts sensitive args, URLs, stdout/stderr, details, and parse-failure spills | `test/agent-browser.extension-validation.test.ts` |
 | Stale `@eN` refs fail mysteriously | Adds recovery guidance to rerun `snapshot -i` or use stable `find` locators | `test/agent-browser.results.test.ts` |
+| Agents need stable success/failure buckets | Exposes bounded `resultCategory`, `successCategory`, and `failureCategory` on tool `details` for branching without parsing prose | [`docs/TOOL_CONTRACT.md`](docs/TOOL_CONTRACT.md#details), `extensions/agent-browser/lib/results/shared.ts`, `test/agent-browser.results.test.ts` |
 | Direct binary help may be blocked in agent sessions | Publishes a repo-readable command reference and verifies it against the target upstream version | `npm run verify` |
 
 ## Fastest way to try it

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,6 +134,7 @@ This keeps the product centered on native tool usage instead of auxiliary skill 
 - subprocess execution and JSON parsing
 - clear missing-binary errors
 - compact result summaries
+- bounded machine-readable outcome metadata on tool `details` (`resultCategory`, `successCategory`, `failureCategory`) so agents can branch without parsing prose; enums and classifier precedence live in `extensions/agent-browser/lib/results/shared.ts` while the human contract lives in [`TOOL_CONTRACT.md`](TOOL_CONTRACT.md#details)
 - inline screenshots/images
 - lightweight session convenience
 - docs, including a repo-readable command reference that mirrors the blocked direct-binary help path closely enough for normal agent work

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -5,6 +5,7 @@ Related docs:
 - [`REQUIREMENTS.md`](REQUIREMENTS.md)
 - [`ARCHITECTURE.md`](ARCHITECTURE.md)
 - [`TOOL_CONTRACT.md`](TOOL_CONTRACT.md)
+- Bounded `agent_browser` outcome categories on `details` (`resultCategory`, `successCategory`, `failureCategory`): contract in [`TOOL_CONTRACT.md`](TOOL_CONTRACT.md#details); maintainer checklist under “Tool result categories” in [`../AGENTS.md`](../AGENTS.md)
 
 ## Purpose
 

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -99,6 +99,7 @@ The design should comfortably support workflows such as:
 - Package-manifest behavior matters more than repo-local development wiring.
 - The extension should use official `pi` hooks and package resources where possible.
 - The wrapper should stay thin, with upstream `agent-browser` remaining the source of truth for command semantics.
+- Successful and failed tool outcomes should surface bounded machine-readable fields on Pi-facing `details` (`resultCategory`, `successCategory`, `failureCategory`) so agents can branch without parsing prose; the contract lives in [`TOOL_CONTRACT.md`](TOOL_CONTRACT.md#details) and the enums plus classifier precedence live in `extensions/agent-browser/lib/results/shared.ts`.
 - User-facing docs belong in `README.md` and the canonical published files under `docs/`.
 - Agent workflow and deeper testing procedures can stay in `AGENTS.md`, but published docs must not depend on that file being present.
 - When upstream `agent-browser` changes, refresh the local command reference, prompt guidance, and other extension-side docs so agents still have a repo-readable equivalent of the blocked direct-binary help path.

--- a/docs/TOOL_CONTRACT.md
+++ b/docs/TOOL_CONTRACT.md
@@ -166,6 +166,8 @@ Recommended details:
   "sessionMode": "auto",
   "sessionName": "pi-abc123",
   "usedImplicitSession": true,
+  "resultCategory": "success",
+  "successCategory": "completed",
   "data": {
     "origin": "https://example.com/",
     "refs": {
@@ -183,7 +185,9 @@ Stable category fields are part of the machine-readable contract:
 - `successCategory`: present on successful results. Current values are `"completed"`, `"artifact-saved"`, and `"inspection"`.
 - `failureCategory`: present on failed results. Current values are `"aborted"`, `"confirmation-required"`, `"download-not-verified"`, `"missing-binary"`, `"parse-failure"`, `"selector-not-found"`, `"selector-unsupported"`, `"stale-ref"`, `"tab-drift"`, `"timeout"`, `"upstream-error"`, and `"validation-error"`.
 
-These categories are intentionally bounded and stable so agents can branch on them instead of parsing prose. They do not replace raw diagnostics: `details.error`, `details.stderr`, `details.parseError`, `details.validationError`, and visible content still preserve the specific upstream or wrapper message after normal redaction. Batch results apply the same fields to `batchSteps[]`, and `batchFailure.failedStep.failureCategory` identifies the first failing step.
+These categories are intentionally bounded and stable so agents can branch on them instead of parsing prose. They do not replace raw diagnostics: `details.error`, `details.stderr`, `details.parseError`, `details.validationError`, and visible content still preserve the specific upstream or wrapper message after normal redaction.
+
+For `batch`, top-level `details` still carries `resultCategory` plus `successCategory` or `failureCategory` for the **aggregate** tool outcome: if any step fails, the overall result is a failure (`resultCategory: "failure"`) even when later steps succeed—inspect `batchSteps[]` for per-step outcomes. Each `batchSteps[]` entry includes its own `resultCategory` and either `successCategory` or `failureCategory` for that step. `batchFailure.failedStep` duplicates the first failing step’s details, including its `failureCategory`.
 
 Implementation and precedence:
 

--- a/docs/TOOL_CONTRACT.md
+++ b/docs/TOOL_CONTRACT.md
@@ -177,6 +177,14 @@ Recommended details:
 }
 ```
 
+Stable category fields are part of the machine-readable contract:
+
+- `resultCategory`: always either `"success"` or `"failure"`.
+- `successCategory`: present on successful results. Current values are `"completed"`, `"artifact-saved"`, and `"inspection"`.
+- `failureCategory`: present on failed results. Current values are `"aborted"`, `"confirmation-required"`, `"download-not-verified"`, `"missing-binary"`, `"parse-failure"`, `"selector-not-found"`, `"selector-unsupported"`, `"stale-ref"`, `"tab-drift"`, `"timeout"`, `"upstream-error"`, and `"validation-error"`.
+
+These categories are intentionally bounded and stable so agents can branch on them instead of parsing prose. They do not replace raw diagnostics: `details.error`, `details.stderr`, `details.parseError`, `details.validationError`, and visible content still preserve the specific upstream or wrapper message after normal redaction. Batch results apply the same fields to `batchSteps[]`, and `batchFailure.failedStep.failureCategory` identifies the first failing step.
+
 Additional structured fields can appear when relevant:
 - `batchFailure` and `batchSteps` for `batch` rendering, including mixed-success runs
 - `navigationSummary` for navigation-style commands like `click`, `back`, `forward`, and `reload`

--- a/docs/TOOL_CONTRACT.md
+++ b/docs/TOOL_CONTRACT.md
@@ -185,6 +185,13 @@ Stable category fields are part of the machine-readable contract:
 
 These categories are intentionally bounded and stable so agents can branch on them instead of parsing prose. They do not replace raw diagnostics: `details.error`, `details.stderr`, `details.parseError`, `details.validationError`, and visible content still preserve the specific upstream or wrapper message after normal redaction. Batch results apply the same fields to `batchSteps[]`, and `batchFailure.failedStep.failureCategory` identifies the first failing step.
 
+Implementation and precedence:
+
+- Types and classifiers live in `extensions/agent-browser/lib/results/shared.ts`: `classifyAgentBrowserSuccessCategory`, `classifyAgentBrowserFailureCategory`, and `buildAgentBrowserResultCategoryDetails` (the last prefers an explicit `failureCategory` when the caller already knows the bucket, otherwise it runs the classifier).
+- Success: if `inspection` is true → `"inspection"`; else if there is a `savedFile` or any `artifacts` → `"artifact-saved"`; else → `"completed"`.
+- Failure: the classifier walks a single ordered chain (first match wins): `confirmation-required` → `timeout` → `missing-binary` → `parse-failure` → `aborted` → `tab-drift` → `stale-ref` (including “unknown ref” text and a narrow `@eN` plus “element not found” heuristic) → `selector-unsupported` → `selector-not-found` → `download-not-verified` (download / wait-download style failures) → `validation-error` when a wrapper `validationError` is present → default `upstream-error`.
+- The main tool implementation merges these fields into Pi-facing `details` from `extensions/agent-browser/index.ts` and from `extensions/agent-browser/lib/results/presentation.ts` for presentation-time failures.
+
 Additional structured fields can appear when relevant:
 - `batchFailure` and `batchSteps` for `batch` rendering, including mixed-success runs
 - `navigationSummary` for navigation-style commands like `click`, `back`, `forward`, and `reload`

--- a/extensions/agent-browser/index.ts
+++ b/extensions/agent-browser/index.ts
@@ -27,6 +27,7 @@ import {
 } from "./lib/playbook.js";
 import { SAFE_AGENT_BROWSER_OPERATION_TIMEOUT_MS, runAgentBrowserProcess } from "./lib/process.js";
 import {
+	buildAgentBrowserResultCategoryDetails,
 	buildToolPresentation,
 	getAgentBrowserErrorText,
 	parseAgentBrowserEnvelope,
@@ -1728,7 +1729,11 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 			if (validationError) {
 				return {
 					content: [{ type: "text", text: validationError }],
-					details: { args: redactedArgs, validationError },
+					details: {
+						args: redactedArgs,
+						...buildAgentBrowserResultCategoryDetails({ args: redactedArgs, errorText: validationError, succeeded: false, validationError }),
+						validationError,
+					},
 					isError: true,
 				};
 			}
@@ -1761,6 +1766,7 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 							sessionMode,
 							sessionRecoveryHint: redactedRecoveryHint,
 							startupScopedFlags: executionPlan.startupScopedFlags,
+							...buildAgentBrowserResultCategoryDetails({ args: redactedArgs, command: executionPlan.commandInfo.command, errorText: executionPlan.validationError, succeeded: false, validationError: executionPlan.validationError }),
 							validationError: executionPlan.validationError,
 						},
 						isError: true,
@@ -1788,6 +1794,7 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 							compatibilityWorkaround,
 							effectiveArgs: redactedEffectiveArgs,
 							sessionMode,
+							...buildAgentBrowserResultCategoryDetails({ args: redactedEffectiveArgs, command: executionPlan.commandInfo.command, errorText: traceOwnerGuardMessage, succeeded: false, validationError: traceOwnerGuardMessage }),
 							validationError: traceOwnerGuardMessage,
 							...buildSessionDetailFields(executionPlan.sessionName, executionPlan.usedImplicitSession),
 						},
@@ -1808,6 +1815,7 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 							compatibilityWorkaround,
 							effectiveArgs: redactedEffectiveArgs,
 							sessionMode,
+							...buildAgentBrowserResultCategoryDetails({ args: redactedEffectiveArgs, command: executionPlan.commandInfo.command, errorText: stdinValidationError, succeeded: false, validationError: stdinValidationError }),
 							validationError: stdinValidationError,
 							...buildSessionDetailFields(executionPlan.sessionName, executionPlan.usedImplicitSession),
 						},
@@ -1824,6 +1832,7 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 							compatibilityWorkaround,
 							effectiveArgs: redactedEffectiveArgs,
 							sessionMode,
+							...buildAgentBrowserResultCategoryDetails({ args: redactedEffectiveArgs, command: executionPlan.commandInfo.command, errorText: waitIpcTimeoutError, succeeded: false, timedOut: true, validationError: waitIpcTimeoutError }),
 							validationError: waitIpcTimeoutError,
 							...buildSessionDetailFields(executionPlan.sessionName, executionPlan.usedImplicitSession),
 						},
@@ -1872,6 +1881,7 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 										effectiveArgs: redactedEffectiveArgs,
 										sessionMode,
 										sessionTabCorrection: plannedSessionTabSelection,
+										...buildAgentBrowserResultCategoryDetails({ args: redactedEffectiveArgs, command: executionPlan.commandInfo.command, errorText: error, failureCategory: "tab-drift", succeeded: false, tabDrift: true, validationError: error }),
 										validationError: error,
 										...buildSessionDetailFields(executionPlan.sessionName, executionPlan.usedImplicitSession),
 									},
@@ -1896,6 +1906,7 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 										effectiveArgs: redactedEffectiveArgs,
 										sessionMode,
 										sessionTabCorrection: plannedSessionTabSelection,
+										...buildAgentBrowserResultCategoryDetails({ args: redactedEffectiveArgs, command: executionPlan.commandInfo.command, errorText: pinnedBatchPlan.error, failureCategory: "tab-drift", succeeded: false, tabDrift: true, validationError: pinnedBatchPlan.error }),
 										validationError: pinnedBatchPlan.error,
 										...buildSessionDetailFields(executionPlan.sessionName, executionPlan.usedImplicitSession),
 									},
@@ -1943,6 +1954,7 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 							effectiveArgs: redactedProcessArgs,
 							sessionMode,
 							sessionTabCorrection,
+							...buildAgentBrowserResultCategoryDetails({ args: redactedProcessArgs, command: executionPlan.commandInfo.command, errorText, failureCategory: "missing-binary", spawnError: processResult.spawnError.message, succeeded: false }),
 							spawnError: processResult.spawnError.message,
 						},
 						isError: true,
@@ -2248,6 +2260,22 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 							? { ...item, text: exactRedactedText }
 							: { ...item, text: redactSensitiveText(exactRedactedText) };
 					});
+					const categoryDetails = buildAgentBrowserResultCategoryDetails({
+						artifacts: presentation.artifacts,
+						args: redactedProcessArgs,
+						command: executionPlan.commandInfo.command,
+						confirmationRequired: presentation.summary.startsWith("Confirmation required"),
+						errorText: errorText ?? presentation.summary,
+						failureCategory: presentation.failureCategory ?? presentation.batchFailure?.failedStep.failureCategory,
+						inspection: plainTextInspection,
+						parseError,
+						savedFile: presentation.savedFile,
+						spawnError: processResult.spawnError?.message,
+						succeeded,
+						tabDrift: !succeeded && (aboutBlankSessionMismatch !== undefined || sessionTabCorrection !== undefined),
+						timedOut: processResult.timedOut,
+						validationError: undefined,
+					});
 					const details = {
 						args: redactedArgs,
 						artifactManifest: presentation.artifactManifest,
@@ -2262,6 +2290,7 @@ export default function agentBrowserExtension(pi: ExtensionAPI) {
 						error: plainTextInspection ? undefined : presentationEnvelope?.error,
 						inspection: plainTextInspection || undefined,
 						navigationSummary,
+						...categoryDetails,
 						aboutBlankSessionMismatch,
 						openResultTabCorrection,
 						effectiveArgs: redactedProcessArgs,

--- a/extensions/agent-browser/lib/results.ts
+++ b/extensions/agent-browser/lib/results.ts
@@ -8,9 +8,18 @@
 
 export { getAgentBrowserErrorText, parseAgentBrowserEnvelope } from "./results/envelope.js";
 export { buildToolPresentation } from "./results/presentation.js";
+export {
+	buildAgentBrowserResultCategoryDetails,
+	classifyAgentBrowserFailureCategory,
+	classifyAgentBrowserSuccessCategory,
+} from "./results/shared.js";
 export type {
 	AgentBrowserBatchResult,
 	AgentBrowserEnvelope,
+	AgentBrowserFailureCategory,
+	AgentBrowserResultCategory,
+	AgentBrowserResultCategoryDetails,
+	AgentBrowserSuccessCategory,
 	FileArtifactKind,
 	FileArtifactMetadata,
 	ToolPresentation,

--- a/extensions/agent-browser/lib/results/presentation.ts
+++ b/extensions/agent-browser/lib/results/presentation.ts
@@ -22,6 +22,9 @@ import { buildSnapshotPresentation, formatRawSnapshotText, formatSnapshotSummary
 import {
 	type AgentBrowserBatchResult,
 	type AgentBrowserEnvelope,
+	buildAgentBrowserResultCategoryDetails,
+	classifyAgentBrowserFailureCategory,
+	classifyAgentBrowserSuccessCategory,
 	type BatchFailurePresentationDetails,
 	type BatchStepPresentationDetails,
 	type ArtifactStorageScope,
@@ -1098,8 +1101,15 @@ async function buildBatchStepPresentation(options: {
 
 	if (item.success === false) {
 		const errorText = formatBatchStepError(item.error);
+		const failureCategory = classifyAgentBrowserFailureCategory({
+			args: command,
+			command: command?.[0],
+			errorText,
+		});
 		const presentation: ToolPresentation = {
 			content: [{ type: "text", text: errorText }],
+			failureCategory,
+			resultCategory: "failure",
 			summary: errorText,
 		};
 		return {
@@ -1108,7 +1118,9 @@ async function buildBatchStepPresentation(options: {
 				command,
 				commandText,
 				data: item.error,
+				failureCategory,
 				index,
+				resultCategory: "failure",
 				success: false,
 				summary: errorText,
 				text: errorText,
@@ -1147,9 +1159,11 @@ async function buildBatchStepPresentation(options: {
 			imagePath: imagePaths[0],
 			imagePaths: imagePaths.length > 0 ? imagePaths : undefined,
 			index,
+			resultCategory: "success",
 			savedFile: presentation.savedFile,
 			savedFilePath: presentation.savedFilePath,
 			success: true,
+			successCategory: classifyAgentBrowserSuccessCategory({ artifacts: presentation.artifacts, savedFile: presentation.savedFile }),
 			summary: presentation.summary,
 			text,
 		},
@@ -1242,11 +1256,14 @@ async function buildBatchPresentation(options: {
 		batchFailure,
 		batchSteps: steps.map((step) => step.details),
 		content: [{ type: "text", text: contentText }, ...images],
+		failureCategory: batchFailure?.failedStep.failureCategory,
 		data,
 		fullOutputPath: fullOutputPaths[0],
 		fullOutputPaths: fullOutputPaths.length > 0 ? fullOutputPaths : undefined,
 		imagePath: imagePaths[0],
 		imagePaths: imagePaths.length > 0 ? imagePaths : undefined,
+		resultCategory: batchFailure ? "failure" : "success",
+		successCategory: batchFailure ? undefined : classifyAgentBrowserSuccessCategory({ artifacts }),
 		summary,
 	};
 }
@@ -1608,6 +1625,7 @@ export async function buildToolPresentation(options: {
 	if (errorText) {
 		const hintedErrorText = appendSelectorRecoveryHint(redactModelFacingText(errorText));
 		return {
+			...buildAgentBrowserResultCategoryDetails({ args: [commandInfo.command, commandInfo.subcommand].filter((item): item is string => item !== undefined), command: commandInfo.command, errorText: hintedErrorText, succeeded: false }),
 			content: [{ type: "text", text: hintedErrorText }],
 			summary: hintedErrorText,
 		};

--- a/extensions/agent-browser/lib/results/shared.ts
+++ b/extensions/agent-browser/lib/results/shared.ts
@@ -19,6 +19,30 @@ export interface AgentBrowserBatchResult {
 	success?: boolean;
 }
 
+export type AgentBrowserResultCategory = "failure" | "success";
+
+export type AgentBrowserSuccessCategory = "artifact-saved" | "completed" | "inspection";
+
+export type AgentBrowserFailureCategory =
+	| "aborted"
+	| "confirmation-required"
+	| "download-not-verified"
+	| "missing-binary"
+	| "parse-failure"
+	| "selector-not-found"
+	| "selector-unsupported"
+	| "stale-ref"
+	| "tab-drift"
+	| "timeout"
+	| "upstream-error"
+	| "validation-error";
+
+export interface AgentBrowserResultCategoryDetails {
+	failureCategory?: AgentBrowserFailureCategory;
+	resultCategory: AgentBrowserResultCategory;
+	successCategory?: AgentBrowserSuccessCategory;
+}
+
 export type FileArtifactKind = "download" | "file" | "har" | "image" | "pdf" | "profile" | "trace" | "video";
 
 export type FileArtifactStatus = "missing" | "repaired-from-temp" | "saved" | "upstream-temp-only";
@@ -191,14 +215,17 @@ export interface BatchStepPresentationDetails {
 	command?: string[];
 	commandText: string;
 	data?: unknown;
+	failureCategory?: AgentBrowserFailureCategory;
 	fullOutputPath?: string;
 	fullOutputPaths?: string[];
 	imagePath?: string;
 	imagePaths?: string[];
 	index: number;
+	resultCategory: AgentBrowserResultCategory;
 	savedFile?: SavedFilePresentationDetails;
 	savedFilePath?: string;
 	success: boolean;
+	successCategory?: AgentBrowserSuccessCategory;
 	summary: string;
 	text: string;
 }
@@ -218,13 +245,97 @@ export interface ToolPresentation {
 	batchSteps?: BatchStepPresentationDetails[];
 	content: Array<{ text: string; type: "text" } | { data: string; mimeType: string; type: "image" }>;
 	data?: unknown;
+	failureCategory?: AgentBrowserFailureCategory;
 	fullOutputPath?: string;
 	fullOutputPaths?: string[];
 	imagePath?: string;
 	imagePaths?: string[];
+	resultCategory?: AgentBrowserResultCategory;
 	savedFile?: SavedFilePresentationDetails;
 	savedFilePath?: string;
+	successCategory?: AgentBrowserSuccessCategory;
 	summary: string;
+}
+
+export function classifyAgentBrowserSuccessCategory(options: {
+	artifacts?: FileArtifactMetadata[];
+	inspection?: boolean;
+	savedFile?: SavedFilePresentationDetails;
+}): AgentBrowserSuccessCategory {
+	if (options.inspection) return "inspection";
+	if (options.savedFile || (options.artifacts ?? []).length > 0) return "artifact-saved";
+	return "completed";
+}
+
+export function classifyAgentBrowserFailureCategory(options: {
+	args?: string[];
+	command?: string;
+	confirmationRequired?: boolean;
+	errorText?: string;
+	parseError?: string;
+	spawnError?: string;
+	stderr?: string;
+	tabDrift?: boolean;
+	timedOut?: boolean;
+	validationError?: string;
+}): AgentBrowserFailureCategory {
+	const text = [options.errorText, options.validationError, options.parseError, options.spawnError, options.stderr].filter(Boolean).join("\n");
+	const command = options.command ?? "";
+	const usedRef = options.args?.some((arg) => /^@e\d+\b/.test(arg)) ?? false;
+	if (options.confirmationRequired || /confirmation required|pending confirmation|requires confirmation/i.test(text)) return "confirmation-required";
+	if (options.timedOut || /timeout|timed out|watchdog|IPC read timeout|must stay under its 30s IPC read timeout/i.test(text)) return "timeout";
+	if (/ENOENT|not found on PATH|could not find.*agent-browser|agent-browser is required but was not found/i.test(text)) return "missing-binary";
+	if (options.parseError || /invalid JSON|missing boolean success|success field must be boolean|returned no JSON output/i.test(text)) return "parse-failure";
+	if (/aborted/i.test(text)) return "aborted";
+	if (options.tabDrift || /could not re-select the intended tab|about:blank|selected tab looks wrong|tab drift|tab.*wrong/i.test(text)) return "tab-drift";
+	if (/\bUnknown ref\b|\bstale ref\b|@ref may be stale|\bref\b.*\b(?:not found|missing|expired)\b/i.test(text)) return "stale-ref";
+	if (usedRef && /could not locate element|element not found|no element/i.test(text)) return "stale-ref";
+	const mentionsPlaywrightSelectorDialect = /(?:\btext=|:has-text\(|\bgetByRole\b|\bgetByText\b)/i.test(text);
+	const reportsSelectorMatchFailure =
+		/\b(?:no elements? found|failed to find|could not find|unable to find)\b.*\b(?:selector|locator)\b/i.test(text) ||
+		/\b(?:selector|locator)\b.*\b(?:no elements? found|not found|missing|failed to find|could not find|unable to find)\b/i.test(text);
+	if (
+		/\b(?:unsupported|unknown|invalid)\s+(?:selector|locator)\b/i.test(text) ||
+		/\bfailed to parse selector\b/i.test(text) ||
+		/\bselector\b.*\b(?:parse|syntax|unsupported|invalid)\b/i.test(text) ||
+		(mentionsPlaywrightSelectorDialect && reportsSelectorMatchFailure)
+	) {
+		return "selector-unsupported";
+	}
+	if (reportsSelectorMatchFailure) return "selector-not-found";
+	if ((command === "download" || text.includes("wait --download") || /\bdownload\b/i.test(text)) && /missing|not verified|not found|failed|timeout|timed out/i.test(text)) {
+		return "download-not-verified";
+	}
+	if (options.validationError) return "validation-error";
+	return "upstream-error";
+}
+
+export function buildAgentBrowserResultCategoryDetails(options: {
+	artifacts?: FileArtifactMetadata[];
+	args?: string[];
+	command?: string;
+	confirmationRequired?: boolean;
+	errorText?: string;
+	failureCategory?: AgentBrowserFailureCategory;
+	inspection?: boolean;
+	parseError?: string;
+	savedFile?: SavedFilePresentationDetails;
+	spawnError?: string;
+	succeeded: boolean;
+	tabDrift?: boolean;
+	timedOut?: boolean;
+	validationError?: string;
+}): AgentBrowserResultCategoryDetails {
+	if (options.succeeded) {
+		return {
+			resultCategory: "success",
+			successCategory: classifyAgentBrowserSuccessCategory(options),
+		};
+	}
+	return {
+		failureCategory: options.failureCategory ?? classifyAgentBrowserFailureCategory(options),
+		resultCategory: "failure",
+	};
 }
 
 export function stringifyUnknown(value: unknown): string {

--- a/test/agent-browser.extension-validation.test.ts
+++ b/test/agent-browser.extension-validation.test.ts
@@ -535,6 +535,8 @@ test("agentBrowserExtension reports the documented missing agent-browser binary 
 			assert.match(text, /https:\/\/agent-browser\.dev\//);
 			assert.match(text, /https:\/\/github\.com\/vercel-labs\/agent-browser/);
 			assert.match(String(result.details?.spawnError ?? ""), /ENOENT/);
+			assert.equal(result.details?.resultCategory, "failure");
+			assert.equal(result.details?.failureCategory, "missing-binary");
 		});
 	} finally {
 		await rm(tempDir, { force: true, recursive: true });
@@ -654,6 +656,8 @@ process.exit(1);`,
 			assert.equal(JSON.stringify(result.details).includes("super-secret-password"), false);
 			assert.match(JSON.stringify(result.content), /\[REDACTED\]/);
 			assert.match(JSON.stringify(result.details), /\[REDACTED\]/);
+			assert.equal(result.details?.resultCategory, "failure");
+			assert.equal(result.details?.failureCategory, "upstream-error");
 		});
 	} finally {
 		await rm(tempDir, { force: true, recursive: true });
@@ -719,6 +723,8 @@ process.exit(1);`,
 			assert.match(text, /\["confirm", "c_sensitive"\]/);
 			assert.match(text, /\["deny", "c_sensitive"\]/);
 			assert.match(String(result.details?.summary ?? ""), /Confirmation required: c_sensitive/);
+			assert.equal(result.details?.resultCategory, "failure");
+			assert.equal(result.details?.failureCategory, "confirmation-required");
 			assert.doesNotMatch(JSON.stringify(result.content), /user:pass|raw-token|token=secret/);
 			assert.doesNotMatch(JSON.stringify(result.details), /user:pass|raw-token|token=secret/);
 		});
@@ -795,6 +801,8 @@ process.stdout.write(JSON.stringify({ success: true, data: { args } }));`,
 				(result.details?.invalidValueFlag as { flag?: string; reason?: string } | undefined)?.reason,
 				"missing-value",
 			);
+			assert.equal(result.details?.resultCategory, "failure");
+			assert.equal(result.details?.failureCategory, "validation-error");
 			assert.deepEqual(await readInvocationLog(logPath), []);
 		});
 	} finally {
@@ -828,6 +836,8 @@ test("agentBrowserExtension rejects malformed JSON envelopes that omit success",
 			assert.equal(result.details?.summary, MISSING_SUCCESS_PARSE_ERROR);
 			assert.doesNotMatch(String(result.details?.summary ?? ""), /^open completed$/i);
 			assert.equal(result.details?.error, undefined);
+			assert.equal(result.details?.resultCategory, "failure");
+			assert.equal(result.details?.failureCategory, "parse-failure");
 		});
 	} finally {
 		await rm(tempDir, { force: true, recursive: true });
@@ -866,6 +876,8 @@ process.stdout.write(JSON.stringify({ success: true, data: { ok: true } }));`,
 				assert.equal(result.content[0]?.type, "text");
 				assert.match((result.content[0] as { text: string }).text, /30s IPC read timeout/);
 				assert.match(String(result.details?.validationError ?? ""), /25000ms or less/);
+				assert.equal(result.details?.resultCategory, "failure");
+				assert.equal(result.details?.failureCategory, "timeout");
 			}
 			assert.deepEqual(await readInvocationLog(logPath), []);
 		});
@@ -902,6 +914,35 @@ test("agentBrowserExtension forwards wait --download saved-file metadata in deta
 				path: "/tmp/export.csv",
 				subcommand: "--download",
 			});
+			assert.equal(result.details?.resultCategory, "success");
+			assert.equal(result.details?.successCategory, "artifact-saved");
+		});
+	} finally {
+		await rm(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("agentBrowserExtension categorizes failed wait --download verification", { concurrency: false }, async () => {
+	const tempDir = await mkdtemp(join(tmpdir(), "pi-agent-browser-wait-download-failure-"));
+	const basePath = process.env.PATH ?? "";
+	await writeFakeAgentBrowserBinary(
+		tempDir,
+		`process.stdout.write(JSON.stringify({ success: false, error: "Download not verified: file missing at /tmp/export.csv" }));
+process.exit(1);`,
+	);
+
+	try {
+		await withPatchedEnv({ PATH: `${tempDir}:${basePath}` }, async () => {
+			const harness = createExtensionHarness({ cwd: tempDir });
+			await runExtensionEvent(harness.handlers, "session_start", { reason: "new" }, harness.ctx);
+
+			const result = await executeRegisteredTool(harness.tool, harness.ctx, {
+				args: ["wait", "--download", "/tmp/export.csv"],
+			});
+
+			assert.equal(result.isError, true);
+			assert.equal(result.details?.resultCategory, "failure");
+			assert.equal(result.details?.failureCategory, "download-not-verified");
 		});
 	} finally {
 		await rm(tempDir, { force: true, recursive: true });
@@ -956,6 +997,8 @@ process.stdout.write(JSON.stringify({ success: true, data: { tabs: [
 			assert.match(text, /Could not locate element/);
 			assert.match(text, /@ref may be stale/);
 			assert.match(text, /snapshot/);
+			assert.equal(result.details?.resultCategory, "failure");
+			assert.equal(result.details?.failureCategory, "stale-ref");
 		});
 	} finally {
 		await rm(tempDir, { force: true, recursive: true });
@@ -1040,6 +1083,8 @@ process.exit(1);`,
 			assert.match(text, /^agent-browser --json --session \S+ open https:\/\/example\.com\/? reported failure \(exit code 1\)\.$/);
 			assert.deepEqual((result.details?.effectiveArgs as string[] | undefined)?.slice(0, 3), ["--json", "--session", result.details?.sessionName]);
 			assert.deepEqual((result.details?.effectiveArgs as string[] | undefined)?.slice(-2), ["open", "https://example.com/"]);
+			assert.equal(result.details?.resultCategory, "failure");
+			assert.equal(result.details?.failureCategory, "upstream-error");
 		});
 	} finally {
 		await rm(tempDir, { force: true, recursive: true });

--- a/test/agent-browser.presentation.test.ts
+++ b/test/agent-browser.presentation.test.ts
@@ -1008,8 +1008,12 @@ test("buildToolPresentation preserves partial batch results when a later step fa
 	assert.match((presentation.content[0] as { text: string }).text, /snapshot -i/);
 	assert.match((presentation.content[0] as { text: string }).text, /find role\|text\|label/);
 	assert.match((presentation.content[0] as { text: string }).text, /scrollintoview/);
+	assert.equal(presentation.resultCategory, "failure");
+	assert.equal(presentation.failureCategory, "stale-ref");
 	assert.equal(presentation.batchFailure?.failedStep.index, 1);
 	assert.equal(presentation.batchFailure?.failedStep.commandText, "click @zzz");
+	assert.equal(presentation.batchFailure?.failedStep.resultCategory, "failure");
+	assert.equal(presentation.batchFailure?.failedStep.failureCategory, "stale-ref");
 	assert.equal(presentation.batchFailure?.failureCount, 1);
 	assert.equal(presentation.batchFailure?.successCount, 1);
 	assert.equal(presentation.batchFailure?.totalCount, 2);

--- a/test/agent-browser.results.test.ts
+++ b/test/agent-browser.results.test.ts
@@ -11,6 +11,8 @@ import test from "node:test";
 
 import {
 	buildToolPresentation,
+	classifyAgentBrowserFailureCategory,
+	classifyAgentBrowserSuccessCategory,
 	getAgentBrowserErrorText,
 	parseAgentBrowserEnvelope,
 } from "../extensions/agent-browser/lib/results.js";
@@ -22,6 +24,25 @@ import {
 
 const MISSING_SUCCESS_PARSE_ERROR = "agent-browser returned an invalid JSON envelope: missing boolean success field.";
 const NON_BOOLEAN_SUCCESS_PARSE_ERROR = "agent-browser returned an invalid JSON envelope: success field must be boolean.";
+
+test("classifyAgentBrowserFailureCategory locks common machine-readable failure categories", () => {
+	assert.equal(classifyAgentBrowserFailureCategory({ errorText: "Unknown ref: e4", args: ["click", "@e4"] }), "stale-ref");
+	assert.equal(classifyAgentBrowserFailureCategory({ errorText: "Failed to parse selector text=Close" }), "selector-unsupported");
+	assert.equal(classifyAgentBrowserFailureCategory({ errorText: "No elements found for selector .missing" }), "selector-not-found");
+	assert.equal(classifyAgentBrowserFailureCategory({ timedOut: true }), "timeout");
+	assert.equal(classifyAgentBrowserFailureCategory({ errorText: "Download not verified: file missing", command: "download" }), "download-not-verified");
+	assert.equal(classifyAgentBrowserFailureCategory({ errorText: "agent-browser is required but was not found on PATH" }), "missing-binary");
+	assert.equal(classifyAgentBrowserFailureCategory({ parseError: "agent-browser returned invalid JSON" }), "parse-failure");
+	assert.equal(classifyAgentBrowserFailureCategory({ errorText: "Confirmation required: c_demo" }), "confirmation-required");
+	assert.equal(classifyAgentBrowserFailureCategory({ errorText: "agent-browser could not re-select the intended tab before running the command." }), "tab-drift");
+	assert.equal(classifyAgentBrowserFailureCategory({ errorText: "Navigation failed: net::ERR_BLOCKED_BY_CLIENT" }), "upstream-error");
+});
+
+test("classifyAgentBrowserSuccessCategory locks common machine-readable success categories", () => {
+	assert.equal(classifyAgentBrowserSuccessCategory({}), "completed");
+	assert.equal(classifyAgentBrowserSuccessCategory({ inspection: true }), "inspection");
+	assert.equal(classifyAgentBrowserSuccessCategory({ artifacts: [{ absolutePath: "/tmp/a.png", kind: "image", path: "/tmp/a.png" }] }), "artifact-saved");
+});
 
 test("parseCommandInfo skips global flags with values", () => {
 	const commandInfo = parseCommandInfo(["--session", "named", "--profile", "./profile", "tab", "list"]);


### PR DESCRIPTION
## Summary
- add bounded resultCategory/successCategory/failureCategory fields for agent_browser results
- classify direct, preflight, batch, artifact, stale-ref, timeout, parse, missing-binary, confirmation, and upstream failures
- document the machine-readable category contract

## Verification
- npm run verify
- git diff --check
- cueloop machine queue validate

CueLoop: RQ-0058