### PR TITLE
Document expanded Pi lifecycle smoke

### DIFF
--- a/.cueloop/queue.jsonc
+++ b/.cueloop/queue.jsonc
@@ -195,7 +195,7 @@
     },
     {
       "id": "RQ-0055",
-      "status": "doing",
+      "status": "todo",
       "title": "Run Pi lifecycle smoke validation for the expanded agent_browser surface",
       "description": "Validate the updated extension in Pi the way agents actually use it. Exercise both quick isolated mode and configured-source lifecycle mode after the expanded surface lands, including `/reload`, restart, and `/resume` behavior. Cover representative calls from every command family through the native `agent_browser` tool rather than bash. Acceptance criteria: `pi --no-extensions -e .` smoke proves unpublished checkout behavior; `npm run verify -- lifecycle` passes; manual or scripted transcript evidence covers version/help/skills, open/snapshot/click, batch stdin, eval stdin, screenshot artifact, explicit session passthrough, sessionMode fresh, and at least one representative current command from each newly supported family; no lingering tmux sessions, browser sessions, temp artifacts, or scratch files remain.",
       "priority": "medium",
@@ -230,8 +230,7 @@
       "notes": [],
       "request": "Add support for everything in the current version of agent-browser.",
       "created_at": "2026-04-29T13:43:31Z",
-      "updated_at": "2026-05-13T23:44:19.674892000Z",
-      "started_at": "2026-05-13T23:44:19.674892000Z",
+      "updated_at": "2026-05-13T13:40:06.107090000Z",
       "depends_on": [
         "RQ-0046",
         "RQ-0054"

--- a/.cueloop/queue.jsonc
+++ b/.cueloop/queue.jsonc
@@ -195,7 +195,7 @@
     },
     {
       "id": "RQ-0055",
-      "status": "todo",
+      "status": "doing",
       "title": "Run Pi lifecycle smoke validation for the expanded agent_browser surface",
       "description": "Validate the updated extension in Pi the way agents actually use it. Exercise both quick isolated mode and configured-source lifecycle mode after the expanded surface lands, including `/reload`, restart, and `/resume` behavior. Cover representative calls from every command family through the native `agent_browser` tool rather than bash. Acceptance criteria: `pi --no-extensions -e .` smoke proves unpublished checkout behavior; `npm run verify -- lifecycle` passes; manual or scripted transcript evidence covers version/help/skills, open/snapshot/click, batch stdin, eval stdin, screenshot artifact, explicit session passthrough, sessionMode fresh, and at least one representative current command from each newly supported family; no lingering tmux sessions, browser sessions, temp artifacts, or scratch files remain.",
       "priority": "medium",
@@ -230,7 +230,8 @@
       "notes": [],
       "request": "Add support for everything in the current version of agent-browser.",
       "created_at": "2026-04-29T13:43:31Z",
-      "updated_at": "2026-05-13T13:40:06.107090000Z",
+      "updated_at": "2026-05-13T23:44:19.674892000Z",
+      "started_at": "2026-05-13T23:44:19.674892000Z",
       "depends_on": [
         "RQ-0046",
         "RQ-0054"

--- a/README.md
+++ b/README.md
@@ -360,6 +360,8 @@ pi --no-extensions -e .
 
 This bypasses Pi settings and configured extensions. After editing extension code, restart that Pi process to test the new checkout.
 
+For a concrete expanded native-tool smoke matrix (version/help/skills through dashboard/chat families), see [Local development validation](docs/RELEASE.md#local-development-validation) in `docs/RELEASE.md`.
+
 Configured-source lifecycle validation:
 
 ```bash

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -94,6 +94,8 @@ Before publishing, validate both local-checkout modes without mixing their assum
 4. Run a smoke prompt that exercises `agent_browser`.
 5. Restart the `pi` process after extension edits; Pi settings and `/reload` are not the validation target in this isolated mode.
 
+For expanded-surface validation, the smoke prompt should cover native tool invocation rather than shelling out to `agent-browser`: `--version`, `--help`, `skills list`, `skills get core --full`, `open` with `sessionMode: "fresh"`, `snapshot -i`, `click`, `eval --stdin`, `batch` via stdin, `screenshot <path>`, explicit `--session … open` plus `--session … close`, `network requests`, `console` / `errors`, `diff snapshot`, `stream status` plus `stream disable`, `dashboard start` plus `dashboard stop`, and `chat <message>` (credential failure is acceptable evidence of wrapper pass-through when `AI_GATEWAY_API_KEY` is intentionally unset). Clean up any opened browser session with `close`, remove temporary files, and kill the tmux session before ending validation.
+
 ### Configured-source lifecycle validation
 
 Prefer the automated harness for deterministic configured-source lifecycle regression coverage:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -96,6 +96,8 @@ Before publishing, validate both local-checkout modes without mixing their assum
 
 For expanded-surface validation, the smoke prompt should cover native tool invocation rather than shelling out to `agent-browser`: `--version`, `--help`, `skills list`, `skills get core --full`, `open` with `sessionMode: "fresh"`, `snapshot -i`, `click`, `eval --stdin`, `batch` via stdin, `screenshot <path>`, explicit `--session … open` plus `--session … close`, `network requests`, `console` / `errors`, `diff snapshot`, `stream status` plus `stream disable`, `dashboard start` plus `dashboard stop`, and `chat <message>` (credential failure is acceptable evidence of wrapper pass-through when `AI_GATEWAY_API_KEY` is intentionally unset). Clean up any opened browser session with `close`, remove temporary files, and kill the tmux session before ending validation.
 
+This checklist assumes a real `agent-browser` on `PATH`. It complements, but does not overlap, `npm run verify -- lifecycle`: that harness swaps in a fake upstream binary and focuses on `/reload`, full restart, `/resume`, managed-session continuity, and spill-path persistence (`scripts/verify-lifecycle.mjs`), not the full command matrix above.
+
 ### Configured-source lifecycle validation
 
 Prefer the automated harness for deterministic configured-source lifecycle regression coverage:


### PR DESCRIPTION
## Summary
- record RQ-0055 as in-progress in CueLoop
- document the expanded quick isolated Pi smoke checklist and cleanup expectations in release docs

## Validation
- npm run verify -- lifecycle
- isolated Pi smoke: pi --no-extensions -e . in tmux, native agent_browser only
  - covered --version, --help, skills list/get, open with sessionMode fresh, snapshot -i, click, eval --stdin, batch stdin, screenshot artifact, explicit --session open/close, second sessionMode fresh, network requests, console, errors, diff snapshot, stream status/disable, dashboard start/stop, chat credential-failure pass-through
  - closed active browser session, stopped dashboard, disabled stream, killed tmux session, removed /tmp smoke files
- npm run verify
- git diff --check
- cueloop machine queue validate

Reviewer: subagent reviewer found no material findings.