### PR TITLE
fix: add Windows stdio exit fallback for agent-browser

### DIFF
--- a/extensions/agent-browser/lib/process.ts
+++ b/extensions/agent-browser/lib/process.ts
@@ -22,6 +22,7 @@ const PI_AGENT_BROWSER_PROCESS_TIMEOUT_ENV = "PI_AGENT_BROWSER_PROCESS_TIMEOUT_M
 const DEFAULT_AGENT_BROWSER_SOCKET_DIR_PREFIX = "/tmp/piab";
 export const SAFE_AGENT_BROWSER_OPERATION_TIMEOUT_MS = 25_000;
 const DEFAULT_AGENT_BROWSER_PROCESS_TIMEOUT_MS = 28_000;
+const EXIT_STDIO_CLOSE_GRACE_MS = 250;
 const httpProxyEnvName = "http_proxy";
 const httpsProxyEnvName = "https_proxy";
 const allProxyEnvName = "all_proxy";
@@ -204,6 +205,7 @@ export async function runAgentBrowserProcess(options: {
 		let pendingStdoutWrite = Promise.resolve();
 		let stdoutSpillError: Error | undefined;
 		let killTimer: NodeJS.Timeout | undefined;
+		let exitFallbackTimer: NodeJS.Timeout | undefined;
 		let timeoutTimer: NodeJS.Timeout | undefined;
 		let abortListener: (() => void) | undefined;
 		let timedOut = false;
@@ -254,6 +256,9 @@ export async function runAgentBrowserProcess(options: {
 				removeAbortListener();
 				if (killTimer) {
 					clearTimeout(killTimer);
+				}
+				if (exitFallbackTimer) {
+					clearTimeout(exitFallbackTimer);
 				}
 				if (timeoutTimer) {
 					clearTimeout(timeoutTimer);
@@ -325,6 +330,18 @@ export async function runAgentBrowserProcess(options: {
 		child.once("error", (error) => {
 			spawnError = error instanceof Error ? error : new Error(String(error));
 			finish(127);
+		});
+		child.once("exit", (code) => {
+			// On Windows, the upstream daemon can leave stdio handles open in child browser processes.
+			// Prefer normal close so stdout/stderr drain; fall back when inherited pipes never close.
+			exitFallbackTimer = setTimeout(() => {
+				if (!settled) {
+					child.stdout.destroy();
+					child.stderr.destroy();
+				}
+				finish(code ?? (timedOut ? 124 : spawnError ? 127 : 0));
+			}, EXIT_STDIO_CLOSE_GRACE_MS);
+			exitFallbackTimer.unref?.();
 		});
 		child.once("close", (code) => {
 			finish(code ?? (timedOut ? 124 : spawnError ? 127 : 0));


### PR DESCRIPTION
## Summary
- add an `exit` fallback for `runAgentBrowserProcess` when stdout/stderr pipes never emit `close`
- preserve normal `close` handling first so large stdout/stderr can still drain
- destroy inherited stdio handles only in the fallback path

## Why
On Windows, `agent-browser --json --session <name> open https://example.com` succeeds from a shell, but can hang when launched by the Pi wrapper with piped stdio. The upstream browser daemon/Chrome child can leave inherited stdio handles open, so Node never emits `close` for the spawned CLI process even after the CLI exits. Pi then stays on `Running agent-browser...`.

## Verification
- `npx tsc --noEmit`
- Focused real repro via `runAgentBrowserProcess({ args: ["--json", "--session", session, "open", "https://example.com"], timeoutMs: 10000 })` now returns exitCode 0 with the expected Example Domain JSON.
- `npx tsx --test test/agent-browser.process.test.ts` was attempted on Windows; several existing tests failed because their fake `agent-browser` binaries are extensionless/POSIX-style and do not resolve cleanly on Windows, unrelated to this patch.