### PR TITLE
Fix process hang when descendants inherit stdio

### DIFF
--- a/extensions/agent-browser/lib/process.ts
+++ b/extensions/agent-browser/lib/process.ts
@@ -6,7 +6,7 @@
  * Invariants/Assumptions: The binary name is always `agent-browser`, the wrapper never shells out, and callers handle semantic success/error interpretation.
  */
 
-import { spawn } from "node:child_process";
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { chmod, mkdir } from "node:fs/promises";
 import { env as processEnv, platform as processPlatform } from "node:process";
 
@@ -22,6 +22,7 @@ const PI_AGENT_BROWSER_PROCESS_TIMEOUT_ENV = "PI_AGENT_BROWSER_PROCESS_TIMEOUT_M
 const DEFAULT_AGENT_BROWSER_SOCKET_DIR_PREFIX = "/tmp/piab";
 export const SAFE_AGENT_BROWSER_OPERATION_TIMEOUT_MS = 25_000;
 const DEFAULT_AGENT_BROWSER_PROCESS_TIMEOUT_MS = 28_000;
+const EXIT_STDIO_GRACE_MS = 100;
 const httpProxyEnvName = "http_proxy";
 const httpsProxyEnvName = "https_proxy";
 const allProxyEnvName = "all_proxy";
@@ -205,8 +206,10 @@ export async function runAgentBrowserProcess(options: {
 		let stdoutSpillError: Error | undefined;
 		let killTimer: NodeJS.Timeout | undefined;
 		let timeoutTimer: NodeJS.Timeout | undefined;
+		let postExitTimer: NodeJS.Timeout | undefined;
 		let abortListener: (() => void) | undefined;
 		let timedOut = false;
+		let child: ChildProcessWithoutNullStreams | undefined;
 
 		const queueStdoutChunk = (buffer: Buffer) => {
 			stdoutTail = appendTail(stdoutTail, buffer.toString("utf8"), MAX_BUFFERED_STDOUT_TAIL_CHARS);
@@ -258,12 +261,18 @@ export async function runAgentBrowserProcess(options: {
 				if (timeoutTimer) {
 					clearTimeout(timeoutTimer);
 				}
+				if (postExitTimer) {
+					clearTimeout(postExitTimer);
+				}
 				if (stdoutSpillHandle) {
 					await stdoutSpillHandle.close().catch(() => undefined);
 				}
 				if (!spawnError && stdoutSpillError) {
 					spawnError = stdoutSpillError;
 				}
+				child?.stdin?.destroy();
+				child?.stdout?.destroy();
+				child?.stderr?.destroy();
 				resolve({
 					aborted,
 					exitCode,
@@ -277,11 +286,12 @@ export async function runAgentBrowserProcess(options: {
 			});
 		};
 
-		const child = spawn("agent-browser", args, {
+		const spawnedChild = spawn("agent-browser", args, {
 			cwd,
 			env: buildAgentBrowserProcessEnv(processEnv, effectiveEnv),
 			stdio: ["pipe", "pipe", "pipe"],
 		});
+		child = spawnedChild;
 
 		const terminateChild = (reason: "abort" | "timeout") => {
 			if (settled) return;
@@ -290,9 +300,9 @@ export async function runAgentBrowserProcess(options: {
 			} else {
 				timedOut = true;
 			}
-			child.kill("SIGTERM");
+			spawnedChild.kill("SIGTERM");
 			killTimer = setTimeout(() => {
-				child.kill("SIGKILL");
+				spawnedChild.kill("SIGKILL");
 			}, 2_000);
 		};
 		const recordStdinError = (error: unknown) => {
@@ -307,32 +317,44 @@ export async function runAgentBrowserProcess(options: {
 		};
 		const writeChildStdin = () => {
 			if (aborted || signal?.aborted) {
-				child.stdin.destroy();
+				spawnedChild.stdin.destroy();
 				return;
 			}
 			try {
 				if (stdin) {
-					child.stdin.write(stdin);
+					spawnedChild.stdin.write(stdin);
 				}
-				child.stdin.end();
+				spawnedChild.stdin.end();
 			} catch (error) {
 				recordStdinError(error);
-				child.stdin.destroy();
+				spawnedChild.stdin.destroy();
 			}
 		};
 
-		child.stdin.on("error", recordStdinError);
-		child.once("error", (error) => {
+		spawnedChild.stdin.on("error", recordStdinError);
+		spawnedChild.once("error", (error) => {
 			spawnError = error instanceof Error ? error : new Error(String(error));
 			finish(127);
 		});
-		child.once("close", (code) => {
-			finish(code ?? (timedOut ? 124 : spawnError ? 127 : 0));
+		let exited = false;
+		let exitCode: number | null = null;
+		// Prefer `close` so stdout/stderr drain normally, but do not wait forever when a
+		// detached descendant inherits the child's stdio handles and keeps them open.
+		spawnedChild.once("exit", (code) => {
+			exited = true;
+			exitCode = code;
+			postExitTimer = setTimeout(() => {
+				finish(exitCode ?? (timedOut ? 124 : spawnError ? 127 : 0));
+			}, EXIT_STDIO_GRACE_MS);
+			postExitTimer.unref?.();
 		});
-		child.stdout.on("data", (chunk: Buffer | string) => {
+		spawnedChild.once("close", (code) => {
+			finish(code ?? (exited ? exitCode : undefined) ?? (timedOut ? 124 : spawnError ? 127 : 0));
+		});
+		spawnedChild.stdout.on("data", (chunk: Buffer | string) => {
 			queueStdoutChunk(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
 		});
-		child.stderr.on("data", (chunk: Buffer | string) => {
+		spawnedChild.stderr.on("data", (chunk: Buffer | string) => {
 			stderr = appendTail(stderr, chunk.toString(), MAX_BUFFERED_STDERR_CHARS);
 		});
 

--- a/test/agent-browser.process.test.ts
+++ b/test/agent-browser.process.test.ts
@@ -8,10 +8,11 @@
 
 import assert from "node:assert/strict";
 import { getEventListeners } from "node:events";
-import { chmod, mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 
 import {
 	buildAgentBrowserProcessEnv,
@@ -141,6 +142,61 @@ test("runAgentBrowserProcess handles abort during stdin-bearing command", async 
 		assert.equal(processResult.spawnError, undefined);
 		assert.equal(getEventListeners(controller.signal, "abort").length, 0);
 	} finally {
+		await rm(tempDir, { force: true, recursive: true });
+	}
+});
+
+test("runAgentBrowserProcess resolves after exit when descendants keep stdio handles open", async () => {
+	const tempDir = await mkdtemp(join(tmpdir(), "pi-agent-browser-stdio-"));
+	const basePath = process.env.PATH ?? "";
+	const lingerPidPath = join(tempDir, "linger.pid");
+	const fakeScript = `const { spawn } = require("node:child_process");
+const { writeFileSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const linger = spawn(process.execPath, ["-e", "setTimeout(() => process.exit(0), 10000); setInterval(() => undefined, 1000);"], {
+	cwd: tmpdir(),
+	detached: true,
+	stdio: ["ignore", "inherit", "inherit"],
+});
+writeFileSync(process.env.PI_AGENT_BROWSER_TEST_LINGER_PID_PATH, String(linger.pid));
+linger.unref();
+process.stdout.write(JSON.stringify({ success: true, data: { ok: true } }), () => process.exit(0));`;
+	if (process.platform === "win32") {
+		await copyFile(process.execPath, join(tempDir, "agent-browser.exe"));
+		await writeFile(join(tempDir, "open"), fakeScript, "utf8");
+	} else {
+		await writeFakeAgentBrowserBinary(tempDir, fakeScript);
+	}
+	let lingerPid: number | undefined;
+
+	try {
+		const startedAt = Date.now();
+		const processResult = await runAgentBrowserProcess({
+			args: ["open", "https://example.com"],
+			cwd: tempDir,
+			env: {
+				PATH: `${tempDir}${delimiter}${basePath}`,
+				PI_AGENT_BROWSER_TEST_LINGER_PID_PATH: lingerPidPath,
+			},
+			timeoutMs: 3_000,
+		});
+		const elapsedMs = Date.now() - startedAt;
+
+		lingerPid = Number((await readFile(lingerPidPath, "utf8")).trim());
+		assert.equal(processResult.exitCode, 0);
+		assert.equal(processResult.timedOut, false);
+		assert.equal(processResult.spawnError, undefined);
+		assert.match(processResult.stdout, /\"ok\":true/);
+		assert.ok(elapsedMs < 2_500, `expected inherited stdio handles not to delay process resolution, got ${elapsedMs}ms`);
+	} finally {
+		if (Number.isInteger(lingerPid)) {
+			try {
+				process.kill(lingerPid as number, "SIGTERM");
+			} catch {
+				// The linger process may have already exited.
+			}
+		}
+		await delay(process.platform === "win32" ? 250 : 0);
 		await rm(tempDir, { force: true, recursive: true });
 	}
 });


### PR DESCRIPTION
## Summary
- resolve `runAgentBrowserProcess` after the child exits when `close` is delayed by inherited stdio handles
- keep `close` as the preferred completion path and clear the post-exit fallback on cleanup
- add regression coverage for a detached descendant that inherits stdout/stderr

## Testing
- `npx tsc --noEmit`
- `npx tsx --test --test-name-pattern "descendants keep stdio" test/agent-browser.process.test.ts`