### PR TITLE
semanticAction success prose and navigation parity

### DIFF
--- a/extensions/agent-browser/lib/orchestration/browser-run/process-output.ts
+++ b/extensions/agent-browser/lib/orchestration/browser-run/process-output.ts
@@ -20,6 +20,7 @@ import {
 	mergeSessionArtifactManifest,
 } from "../../results/artifact-manifest.js";
 import type { SessionArtifactManifest } from "../../results/contracts.js";
+import { shouldCaptureSemanticActionNavigationSummary } from "../../results/presentation/semantic-action.js";
 import {
 	commandExplicitlyTargetsAboutBlank,
 	deriveSessionTabTarget,
@@ -205,7 +206,12 @@ export async function processBrowserOutput(input: ProcessBrowserOutputInput): Pr
 		const inspectionText = plainTextInspection ? processResult.stdout.trim() : undefined;
 		updateTraceOwnerState({ command: prepared.executionPlan.commandInfo.command, sessionName: prepared.executionPlan.sessionName, subcommand: prepared.executionPlan.commandInfo.subcommand, succeeded, traceOwners });
 
-		if (succeeded && !navigationSummary && shouldCaptureNavigationSummary(prepared.executionPlan.commandInfo.command, presentationEnvelope?.data)) {
+		if (
+			succeeded &&
+			!navigationSummary &&
+			(shouldCaptureNavigationSummary(prepared.executionPlan.commandInfo.command, presentationEnvelope?.data) ||
+				shouldCaptureSemanticActionNavigationSummary(prepared.compiledSemanticAction, presentationEnvelope?.data))
+		) {
 			navigationSummary = await collectNavigationSummary({ cwd, sessionName: prepared.executionPlan.sessionName, signal });
 		}
 		if (navigationSummary && presentationEnvelope) presentationEnvelope = { ...presentationEnvelope, data: mergeNavigationSummaryIntoData(presentationEnvelope.data, navigationSummary) };
@@ -341,7 +347,7 @@ export async function processBrowserOutput(input: ProcessBrowserOutputInput): Pr
 		}
 
 		const errorText = getAgentBrowserErrorText({ aborted: processResult.aborted, command: prepared.executionPlan.commandInfo.command, effectiveArgs: prepared.redactedProcessArgs, envelope: presentationEnvelope, exitCode: processResult.exitCode, parseError, plainTextInspection, staleRefArgs: getStaleRefArgs(prepared.commandTokens, prepared.runtimeToolStdin), spawnError: processResult.spawnError, stderr: processResult.stderr, timedOut: processResult.timedOut, timeoutMs: processResult.timeoutMs, wrapperRecoveryHint: buildWrapperRecoveryHint({ pinnedBatchUnwrapMode: prepared.pinnedBatchUnwrapMode, sessionTabCorrection }) });
-		const presentation = plainTextInspection ? { artifacts: undefined, batchFailure: undefined, batchSteps: undefined, content: [{ type: "text" as const, text: inspectionText ?? "" }], data: undefined, fullOutputPath: undefined, fullOutputPaths: undefined, imagePath: undefined, imagePaths: undefined, savedFile: undefined, savedFilePath: undefined, summary: `${prepared.redactedArgs.join(" ")} completed` } : await buildToolPresentation({ args: prepared.redactedProcessArgs, artifactManifest, artifactRequest: screenshotArtifactRequest, batchArtifactRequests: batchScreenshotArtifactRequests, commandInfo: prepared.executionPlan.commandInfo, cwd, envelope: presentationEnvelope, errorText, persistentArtifactStore, sessionName: prepared.executionPlan.sessionName });
+		const presentation = plainTextInspection ? { artifacts: undefined, batchFailure: undefined, batchSteps: undefined, content: [{ type: "text" as const, text: inspectionText ?? "" }], data: undefined, fullOutputPath: undefined, fullOutputPaths: undefined, imagePath: undefined, imagePaths: undefined, savedFile: undefined, savedFilePath: undefined, summary: `${prepared.redactedArgs.join(" ")} completed` } : await buildToolPresentation({ args: prepared.redactedProcessArgs, artifactManifest, artifactRequest: screenshotArtifactRequest, batchArtifactRequests: batchScreenshotArtifactRequests, commandInfo: prepared.executionPlan.commandInfo, compiledSemanticAction: prepared.compiledSemanticAction, cwd, envelope: presentationEnvelope, errorText, persistentArtifactStore, sessionName: prepared.executionPlan.sessionName });
 		if (parseFailureOutput.artifactManifest) { presentation.artifactManifest = parseFailureOutput.artifactManifest; presentation.artifactRetentionSummary = parseFailureOutput.artifactRetentionSummary; }
 		if (parseFailureOutput.fullOutputPath || parseFailureOutput.fullOutputUnavailable) {
 			const existingText = presentation.content[0]?.type === "text" ? presentation.content[0].text : "";

--- a/extensions/agent-browser/lib/results/presentation.ts
+++ b/extensions/agent-browser/lib/results/presentation.ts
@@ -4,6 +4,7 @@
  * Scope: Presentation shaping only; upstream stdout parsing and snapshot compaction internals live in separate modules.
  */
 
+import type { CompiledAgentBrowserSemanticAction } from "../input-modes/types.js";
 import { isRecord } from "../parsing.js";
 import type { CommandInfo } from "../runtime.js";
 import type { PersistentSessionArtifactStore } from "../temp.js";
@@ -43,6 +44,7 @@ import { buildErrorPresentation } from "./presentation/errors.js";
 import { compactLargePresentationOutput } from "./presentation/large-output.js";
 import { buildPageChangeSummary } from "./presentation/navigation.js";
 import { formatPresentationContentText, formatPresentationSummary } from "./presentation/registry.js";
+import { resolvePresentationCommandInfo } from "./presentation/semantic-action.js";
 
 function sanitizeModelFacingPresentation(presentation: ToolPresentation): ToolPresentation {
 	presentation.content = presentation.content.map((item) => {
@@ -65,6 +67,7 @@ export async function buildToolPresentation(options: {
 	artifactRequest?: ArtifactRequestContext;
 	batchArtifactRequests?: Array<ArtifactRequestContext | undefined>;
 	commandInfo: CommandInfo;
+	compiledSemanticAction?: CompiledAgentBrowserSemanticAction;
 	cwd: string;
 	envelope?: AgentBrowserEnvelope;
 	errorText?: string;
@@ -76,12 +79,14 @@ export async function buildToolPresentation(options: {
 		artifactManifest,
 		artifactRequest,
 		commandInfo,
+		compiledSemanticAction,
 		cwd,
 		envelope,
 		errorText,
 		persistentArtifactStore,
 		sessionName,
 	} = options;
+	const presentationCommandInfo = resolvePresentationCommandInfo(commandInfo, compiledSemanticAction);
 
 	if (errorText) {
 		return buildErrorPresentation({ args, commandInfo, errorText, sessionName });
@@ -89,10 +94,10 @@ export async function buildToolPresentation(options: {
 
 	const data = enrichStreamStatusData(commandInfo, envelope?.data);
 	const presentationData = redactPresentationData(commandInfo, data);
-	const artifacts = await extractFileArtifacts({ artifactRequest, commandInfo, cwd, data, sessionName });
+	const artifacts = await extractFileArtifacts({ artifactRequest, commandInfo: presentationCommandInfo, cwd, data, sessionName });
 	const artifactVerification = buildArtifactVerificationSummary(artifacts);
 	const artifactSummary = formatArtifactSummary(artifacts);
-	const summary = artifactSummary ?? formatPresentationSummary(commandInfo, data);
+	const summary = artifactSummary ?? formatPresentationSummary(commandInfo, data, compiledSemanticAction);
 	const artifactText = artifacts.length > 0 ? formatArtifactMetadataLines(artifacts).join("\n") : undefined;
 
 	let presentation: ToolPresentation;
@@ -113,7 +118,7 @@ export async function buildToolPresentation(options: {
 		presentation = {
 			artifactVerification,
 			artifacts: artifacts.length > 0 ? artifacts : undefined,
-			content: [{ type: "text", text: artifactText ?? formatPresentationContentText(commandInfo, data) }],
+			content: [{ type: "text", text: artifactText ?? formatPresentationContentText(commandInfo, data, compiledSemanticAction) }],
 			data: presentationData,
 			summary,
 		};
@@ -159,7 +164,7 @@ export async function buildToolPresentation(options: {
 	if (!presentationWithManifest.resultCategory) {
 		const categoryDetails = buildAgentBrowserResultCategoryDetails({
 			artifacts: presentationWithManifest.artifacts,
-			command: commandInfo.command,
+			command: presentationCommandInfo.command,
 			confirmationRequired: confirmationRequired !== undefined,
 			errorText: envelope?.success === false ? presentationWithManifest.summary : undefined,
 			savedFile: presentationWithManifest.savedFile,
@@ -186,7 +191,7 @@ export async function buildToolPresentation(options: {
 	const genericNextActions = presentationWithManifest.nextActions ? undefined : buildAgentBrowserNextActions({
 		artifacts: presentationWithManifest.artifacts,
 		args,
-		command: commandInfo.command,
+		command: presentationCommandInfo.command,
 		confirmationId: confirmationRequired?.id,
 		failureCategory: presentationWithManifest.failureCategory,
 		resultCategory: presentationWithManifest.resultCategory ?? "success",
@@ -203,7 +208,7 @@ export async function buildToolPresentation(options: {
 	);
 	presentationWithManifest.pageChangeSummary = presentationWithManifest.pageChangeSummary ?? buildPageChangeSummary({
 		artifacts: presentationWithManifest.artifacts,
-		commandInfo,
+		commandInfo: presentationCommandInfo,
 		data,
 		nextActions: presentationWithManifest.nextActions,
 		savedFilePath: presentationWithManifest.savedFilePath,

--- a/extensions/agent-browser/lib/results/presentation/registry.ts
+++ b/extensions/agent-browser/lib/results/presentation/registry.ts
@@ -1,3 +1,4 @@
+import type { CompiledAgentBrowserSemanticAction } from "../../input-modes/types.js";
 import { isRecord } from "../../parsing.js";
 import type { CommandInfo } from "../../runtime.js";
 import { detectConfirmationRequired, type ConfirmationRequiredPresentation } from "../confirmation.js";
@@ -14,6 +15,11 @@ import {
 	getNavigationSummary,
 	isNavigationObservableCommand,
 } from "./navigation.js";
+import {
+	formatSemanticActionPresentationSummary,
+	formatSemanticActionPresentationText,
+	resolvePresentationCommandInfo,
+} from "./semantic-action.js";
 
 function getPageSummary(data: Record<string, unknown>): string | undefined {
 	const title = typeof data.title === "string" ? data.title : undefined;
@@ -91,9 +97,15 @@ function formatBatchSummary(data: unknown): string | undefined {
 		: `Batch failed: ${successCount}/${data.length} succeeded`;
 }
 
-export function formatPresentationSummary(commandInfo: CommandInfo, data: unknown): string {
+export function formatPresentationSummary(
+	commandInfo: CommandInfo,
+	data: unknown,
+	compiledSemanticAction?: CompiledAgentBrowserSemanticAction,
+): string {
 	const confirmationRequired = detectConfirmationRequired(data);
 	if (confirmationRequired) return formatConfirmationRequiredSummary(confirmationRequired);
+
+	const presentationCommandInfo = resolvePresentationCommandInfo(commandInfo, compiledSemanticAction);
 
 	if (commandInfo.command === "batch") {
 		const batchSummary = formatBatchSummary(data);
@@ -101,10 +113,16 @@ export function formatPresentationSummary(commandInfo: CommandInfo, data: unknow
 	}
 
 	if (isRecord(data)) {
+		if (compiledSemanticAction) {
+			const semanticSummary = formatSemanticActionPresentationSummary(compiledSemanticAction, data);
+			if (semanticSummary) return semanticSummary;
+		}
 		const navigationSummary = getNavigationSummary(data);
-		if (navigationSummary && isNavigationObservableCommand(commandInfo.command)) {
+		if (navigationSummary && isNavigationObservableCommand(presentationCommandInfo.command)) {
 			const navigationText = formatNavigationSummary(navigationSummary);
-			if (navigationText) return `${commandInfo.command ?? "navigation"} → ${navigationText.split("\n", 1)[0] ?? navigationText}`;
+			if (navigationText) {
+				return `${presentationCommandInfo.command ?? "navigation"} → ${navigationText.split("\n", 1)[0] ?? navigationText}`;
+			}
 		}
 	}
 
@@ -121,10 +139,14 @@ export function formatPresentationSummary(commandInfo: CommandInfo, data: unknow
 	}
 
 	if (typeof data === "string" && data.length > 0) return data.split("\n", 1)[0] ?? data;
-	return `${commandInfo.command ?? "agent-browser"} completed`;
+	return `${presentationCommandInfo.command ?? commandInfo.command ?? "agent-browser"} completed`;
 }
 
-export function formatPresentationContentText(commandInfo: CommandInfo, data: unknown): string {
+export function formatPresentationContentText(
+	commandInfo: CommandInfo,
+	data: unknown,
+	compiledSemanticAction?: CompiledAgentBrowserSemanticAction,
+): string {
 	const confirmationRequired = detectConfirmationRequired(data);
 	if (confirmationRequired) return formatConfirmationRequiredText(confirmationRequired);
 
@@ -135,8 +157,14 @@ export function formatPresentationContentText(commandInfo: CommandInfo, data: un
 	if (typeof data === "number" || typeof data === "boolean") return String(data);
 	if (!isRecord(data)) return stringifyModelFacing(data);
 
+	if (compiledSemanticAction) {
+		const semanticText = formatSemanticActionPresentationText(compiledSemanticAction, data);
+		if (semanticText) return semanticText;
+	}
+
+	const presentationCommandInfo = resolvePresentationCommandInfo(commandInfo, compiledSemanticAction);
 	const navigationSummary = getNavigationSummary(data);
-	if (navigationSummary && isNavigationObservableCommand(commandInfo.command)) {
+	if (navigationSummary && isNavigationObservableCommand(presentationCommandInfo.command)) {
 		const navigationText = formatNavigationSummary(navigationSummary);
 		if (navigationText) {
 			const actionText = formatNavigationActionResult(data);

--- a/extensions/agent-browser/lib/results/presentation/semantic-action.ts
+++ b/extensions/agent-browser/lib/results/presentation/semantic-action.ts
@@ -30,10 +30,6 @@ function getPageSummary(data: Record<string, unknown>): string | undefined {
 	return title ?? url;
 }
 
-function isLocatedSelectorToken(value: string): boolean {
-	return value.includes("data-agent-browser-located");
-}
-
 function formatSemanticActionTarget(compiled: CompiledAgentBrowserSemanticAction): string {
 	if (compiled.action === "select") {
 		const selector = compiled.selector ?? "selector";
@@ -111,16 +107,6 @@ export function formatSemanticActionPresentationText(
 
 	const pageSummary = getPageSummary(data);
 	if (pageSummary) return `${actionLine}\n\nCurrent page:\n${redactModelFacingText(pageSummary)}`;
-
-	const clicked = data.clicked;
-	if (
-		typeof clicked === "string" &&
-		isLocatedSelectorToken(clicked) &&
-		!navigationSummary &&
-		!pageSummary
-	) {
-		return actionLine;
-	}
 
 	return actionLine;
 }

--- a/extensions/agent-browser/lib/results/presentation/semantic-action.ts
+++ b/extensions/agent-browser/lib/results/presentation/semantic-action.ts
@@ -1,0 +1,147 @@
+/**
+ * Purpose: Map successful semanticAction results to the same presentation signals as direct ref commands.
+ * Responsibilities: Resolve presentation command names, compact action prose, and navigation-summary probe gates.
+ * Scope: semanticAction success presentation only.
+ */
+
+import {
+	getCompiledSemanticActionCommandIndex,
+	isCompiledSemanticActionFindCommand,
+} from "../../input-modes/semantic-action.js";
+import type { CompiledAgentBrowserSemanticAction } from "../../input-modes/types.js";
+import { isRecord } from "../../parsing.js";
+import type { CommandInfo } from "../../runtime.js";
+import {
+	formatNavigationSummary,
+	getNavigationSummary,
+	isNavigationObservableCommand,
+} from "./navigation.js";
+import { redactModelFacingText } from "./common.js";
+
+const SEMANTIC_NAVIGATION_PROBE_ACTIONS = new Set(["check", "click", "uncheck"]);
+
+const SEMANTIC_PRESENTATION_ACTIONS = new Set(["check", "click", "fill", "select", "uncheck"]);
+
+function getPageSummary(data: Record<string, unknown>): string | undefined {
+	const title = typeof data.title === "string" ? data.title : undefined;
+	const url = typeof data.url === "string" ? data.url : undefined;
+	if (!title && !url) return undefined;
+	if (title && url) return `${title}\n${url}`;
+	return title ?? url;
+}
+
+function isLocatedSelectorToken(value: string): boolean {
+	return value.includes("data-agent-browser-located");
+}
+
+function formatSemanticActionTarget(compiled: CompiledAgentBrowserSemanticAction): string {
+	if (compiled.action === "select") {
+		const selector = compiled.selector ?? "selector";
+		const values = compiled.values?.length ? compiled.values.join(", ") : "";
+		return values ? `${selector} → ${values}` : selector;
+	}
+	const commandIndex = getCompiledSemanticActionCommandIndex(compiled);
+	const locator = compiled.locator ?? compiled.args[commandIndex + 1] ?? "locator";
+	const locatorValue = compiled.args[commandIndex + 2];
+	const nameIndex = compiled.args.indexOf("--name");
+	const name = nameIndex >= 0 ? compiled.args[nameIndex + 1] : undefined;
+	const quotedValue = JSON.stringify(locatorValue ?? "");
+	const target = `${locator} ${quotedValue}`;
+	return name ? `${target} (name ${JSON.stringify(name)})` : target;
+}
+
+export function formatSemanticActionCompactLine(compiled: CompiledAgentBrowserSemanticAction): string {
+	const target = formatSemanticActionTarget(compiled);
+	switch (compiled.action) {
+		case "click":
+			return `Clicked: ${target}`;
+		case "fill":
+			return `Filled: ${target}`;
+		case "check":
+			return `Checked: ${target}`;
+		case "uncheck":
+			return `Unchecked: ${target}`;
+		case "select":
+			return `Selected: ${target}`;
+		default:
+			return `${compiled.action}: ${target}`;
+	}
+}
+
+export function resolveSemanticPresentationCommand(
+	compiled: CompiledAgentBrowserSemanticAction | undefined,
+): string | undefined {
+	if (!compiled || !SEMANTIC_PRESENTATION_ACTIONS.has(compiled.action)) return undefined;
+	if (compiled.action === "select") return "select";
+	if (isCompiledSemanticActionFindCommand(compiled)) return compiled.action;
+	return undefined;
+}
+
+export function resolvePresentationCommandInfo(
+	commandInfo: CommandInfo,
+	compiledSemanticAction?: CompiledAgentBrowserSemanticAction,
+): CommandInfo {
+	const presentationCommand = resolveSemanticPresentationCommand(compiledSemanticAction);
+	if (!presentationCommand) return commandInfo;
+	return { ...commandInfo, command: presentationCommand };
+}
+
+export function shouldCaptureSemanticActionNavigationSummary(
+	compiled: CompiledAgentBrowserSemanticAction | undefined,
+	data: unknown,
+): boolean {
+	if (!compiled || !SEMANTIC_NAVIGATION_PROBE_ACTIONS.has(compiled.action)) return false;
+	if (!isCompiledSemanticActionFindCommand(compiled)) return false;
+	return !isRecord(data) || (typeof data.title !== "string" && typeof data.url !== "string");
+}
+
+export function formatSemanticActionPresentationText(
+	compiled: CompiledAgentBrowserSemanticAction,
+	data: Record<string, unknown>,
+): string | undefined {
+	const presentationCommand = resolveSemanticPresentationCommand(compiled);
+	if (!presentationCommand) return undefined;
+
+	const actionLine = formatSemanticActionCompactLine(compiled);
+	const navigationSummary = getNavigationSummary(data);
+	if (navigationSummary && isNavigationObservableCommand(presentationCommand)) {
+		const navigationText = formatNavigationSummary(navigationSummary);
+		if (navigationText) return `${actionLine}\n\nCurrent page:\n${navigationText}`;
+	}
+
+	const pageSummary = getPageSummary(data);
+	if (pageSummary) return `${actionLine}\n\nCurrent page:\n${redactModelFacingText(pageSummary)}`;
+
+	const clicked = data.clicked;
+	if (
+		typeof clicked === "string" &&
+		isLocatedSelectorToken(clicked) &&
+		!navigationSummary &&
+		!pageSummary
+	) {
+		return actionLine;
+	}
+
+	return actionLine;
+}
+
+export function formatSemanticActionPresentationSummary(
+	compiled: CompiledAgentBrowserSemanticAction,
+	data: Record<string, unknown>,
+): string | undefined {
+	const presentationCommand = resolveSemanticPresentationCommand(compiled);
+	if (!presentationCommand) return undefined;
+
+	const navigationSummary = getNavigationSummary(data);
+	if (navigationSummary && isNavigationObservableCommand(presentationCommand)) {
+		const navigationText = formatNavigationSummary(navigationSummary);
+		if (navigationText) {
+			return `${presentationCommand} → ${navigationText.split("\n", 1)[0] ?? navigationText}`;
+		}
+	}
+
+	const pageSummary = getPageSummary(data);
+	if (pageSummary) return `${presentationCommand} → ${pageSummary.split("\n", 1)[0] ?? pageSummary}`;
+
+	return `${presentationCommand} → ${formatSemanticActionTarget(compiled)}`;
+}

--- a/test/agent-browser.extension-semantic-success.test.ts
+++ b/test/agent-browser.extension-semantic-success.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Purpose: Extension-level semanticAction success prose and navigation probe coverage.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+	createExtensionHarness,
+	executeRegisteredTool,
+	readInvocationLog,
+	runExtensionEvent,
+	withPatchedEnv,
+	writeFakeAgentBrowserBinary,
+} from "./helpers/agent-browser-harness.js";
+
+test("agentBrowserExtension enriches semanticAction click success with page state probe and prose parity", { concurrency: false }, async () => {
+	const tempDir = await mkdtemp(join(tmpdir(), "pi-agent-browser-semantic-success-"));
+	const logPath = join(tempDir, "invocations.log");
+	const basePath = process.env.PATH ?? "";
+	await writeFakeAgentBrowserBinary(
+		tempDir,
+		`const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ args }) + "\\n");
+const valueFlags = new Set(["--session"]);
+let commandIndex = -1;
+for (let i = 0; i < args.length; i += 1) {
+  const token = args[i];
+  if (token === "--json") continue;
+  if (valueFlags.has(token)) { i += 1; continue; }
+  if (token.startsWith("--")) continue;
+  commandIndex = i;
+  break;
+}
+const command = args[commandIndex];
+if (command === "find") {
+  process.stdout.write(JSON.stringify({ success: true, data: { clicked: "[data-agent-browser-located='true']" } }));
+} else if (command === "eval") {
+  process.stdout.write(JSON.stringify({ success: true, data: { result: { title: "Example Domain", url: "https://example.test/" } } }));
+} else if (command === "click") {
+  process.stdout.write(JSON.stringify({ success: true, data: { clicked: true, href: "https://example.test/docs", navigationSummary: { title: "Docs", url: "https://example.test/docs" } } }));
+} else {
+  process.stdout.write(JSON.stringify({ success: true, data: { ok: true } }));
+}`,
+	);
+
+	try {
+		await withPatchedEnv({ PATH: `${tempDir}:${basePath}` }, async () => {
+			const harness = createExtensionHarness({ cwd: tempDir });
+			await runExtensionEvent(harness.handlers, "session_start", { reason: "new" }, harness.ctx);
+
+			const semanticClick = await executeRegisteredTool(harness.tool, harness.ctx, {
+				semanticAction: { action: "click", locator: "text", value: "Close" },
+			});
+			assert.equal(semanticClick.isError, false);
+			const semanticText = (semanticClick.content[0] as { text: string }).text;
+			assert.match(semanticText, /Clicked: text "Close"/);
+			assert.doesNotMatch(semanticText, /data-agent-browser-located/);
+			assert.match(semanticText, /Current page:/);
+			assert.match(semanticText, /Example Domain/);
+			assert.match(semanticText, /https:\/\/example.test\//);
+			assert.match(semanticClick.details?.summary as string, /click → Example Domain/);
+			assert.deepEqual(
+				(semanticClick.details?.navigationSummary as { title?: string; url?: string } | undefined),
+				{ title: "Example Domain", url: "https://example.test/" },
+			);
+			assert.equal(
+				(semanticClick.details?.pageChangeSummary as { command?: string; changeType?: string } | undefined)?.command,
+				"click",
+			);
+			assert.equal(
+				(semanticClick.details?.pageChangeSummary as { command?: string; changeType?: string } | undefined)?.changeType,
+				"navigation",
+			);
+			const nextActionIds = (semanticClick.details?.nextActions as Array<{ id: string }> | undefined)?.map((action) => action.id);
+			assert.ok(nextActionIds?.includes("inspect-after-mutation"));
+
+			const directClick = await executeRegisteredTool(harness.tool, harness.ctx, {
+				args: ["click", "#direct"],
+			});
+			assert.equal(directClick.isError, false);
+			const directText = (directClick.content[0] as { text: string }).text;
+			assert.match(directText, /Clicked: true/);
+			assert.match(directText, /Href: https:\/\/example.test\/docs/);
+			assert.match(directText, /Current page:/);
+
+			const invocations = await readInvocationLog(logPath);
+			const evalProbe = invocations.find((entry) => entry.args.includes("eval"));
+			assert.ok(evalProbe, "expected read-only page-state eval after semantic click");
+		});
+	} finally {
+		await rm(tempDir, { force: true, recursive: true });
+	}
+});

--- a/test/agent-browser.presentation-semantic-action.test.ts
+++ b/test/agent-browser.presentation-semantic-action.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Purpose: Lock semanticAction success presentation parity with direct ref commands.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildToolPresentation } from "../extensions/agent-browser/lib/results/presentation.js";
+import {
+	formatSemanticActionCompactLine,
+	formatSemanticActionPresentationText,
+	shouldCaptureSemanticActionNavigationSummary,
+} from "../extensions/agent-browser/lib/results/presentation/semantic-action.js";
+
+const semanticClick = {
+	action: "click" as const,
+	locator: "text" as const,
+	args: ["find", "text", "Close", "click"],
+};
+
+test("formatSemanticActionCompactLine avoids raw located-selector clicked tokens", () => {
+	const line = formatSemanticActionCompactLine(semanticClick);
+	assert.match(line, /Clicked: text "Close"/);
+	assert.doesNotMatch(line, /data-agent-browser-located/);
+});
+
+test("formatSemanticActionPresentationText prefers compact action line over located selector", () => {
+	const text = formatSemanticActionPresentationText(semanticClick, {
+		clicked: "[data-agent-browser-located='true']",
+	});
+	assert.match(text ?? "", /Clicked: text "Close"/);
+	assert.doesNotMatch(text ?? "", /data-agent-browser-located/);
+});
+
+test("shouldCaptureSemanticActionNavigationSummary probes find click without title or url", () => {
+	assert.equal(
+		shouldCaptureSemanticActionNavigationSummary(semanticClick, { clicked: "[data-agent-browser-located='true']" }),
+		true,
+	);
+	assert.equal(
+		shouldCaptureSemanticActionNavigationSummary(semanticClick, {
+			clicked: true,
+			title: "Example",
+			url: "https://example.test/",
+		}),
+		false,
+	);
+	assert.equal(shouldCaptureSemanticActionNavigationSummary({ ...semanticClick, action: "fill" }, { filled: true }), false);
+});
+
+test("buildToolPresentation enriches semanticAction find click like direct click", async () => {
+	const presentation = await buildToolPresentation({
+		commandInfo: { command: "find", subcommand: "text" },
+		compiledSemanticAction: semanticClick,
+		cwd: process.cwd(),
+		envelope: {
+			success: true,
+			data: {
+				clicked: "[data-agent-browser-located='true']",
+				navigationSummary: {
+					title: "Destination Docs",
+					url: "https://example.com/docs",
+				},
+			},
+		},
+	});
+
+	assert.equal(presentation.content[0]?.type, "text");
+	const text = (presentation.content[0] as { text: string }).text;
+	assert.match(text, /Clicked: text "Close"/);
+	assert.match(text, /Current page:/);
+	assert.match(text, /Destination Docs/);
+	assert.match(text, /https:\/\/example.com\/docs/);
+	assert.match(presentation.summary, /click → Destination Docs/);
+	assert.equal(presentation.pageChangeSummary?.changeType, "navigation");
+	assert.equal(presentation.pageChangeSummary?.command, "click");
+	assert.deepEqual(presentation.nextActions?.[0]?.params?.args, ["snapshot", "-i"]);
+});
+
+test("buildToolPresentation preserves direct click presentation", async () => {
+	const presentation = await buildToolPresentation({
+		commandInfo: { command: "click" },
+		cwd: process.cwd(),
+		envelope: {
+			success: true,
+			data: {
+				clicked: true,
+				href: "https://example.com/docs",
+				navigationSummary: {
+					title: "Destination Docs",
+					url: "https://example.com/docs",
+				},
+			},
+		},
+	});
+
+	const text = (presentation.content[0] as { text: string }).text;
+	assert.match(text, /Clicked: true/);
+	assert.match(text, /Href: https:\/\/example.com\/docs/);
+	assert.match(text, /Current page:/);
+	assert.match(presentation.summary, /click → Destination Docs/);
+});


### PR DESCRIPTION
## Summary
- Map successful `semanticAction` find/select results to the same presentation command surface as direct `click`/`fill`/`select`/`check`/`uncheck` calls so summaries, page-change summaries, and `inspect-after-mutation` next actions align.
- Add compact semantic target prose instead of surfacing raw upstream `data-agent-browser-located` clicked tokens as the primary model-visible signal.
- Probe current page title/URL with the existing read-only eval helper when semantic click/check/uncheck upstream JSON omits navigation fields.

## Test plan
- [x] `npm run typecheck`
- [x] `npx tsx --test test/agent-browser.presentation-semantic-action.test.ts`
- [x] `npx tsx --test test/agent-browser.extension-semantic-success.test.ts`
- [x] `npx tsx --test test/agent-browser.presentation.test.ts` (direct click regression)


Made with [Cursor](https://cursor.com)