### PR TITLE
fix: tolerate absent branch restore identity list in ManagedSessionRestoreState.replace

### DIFF
--- a/extensions/agent-browser/lib/managed-session-restore.ts
+++ b/extensions/agent-browser/lib/managed-session-restore.ts
@@ -104,7 +104,7 @@ export class ManagedSessionRestoreState {
 		if (sessionName) this.#daemonRestoreKeys.set(getAgentBrowserSessionIdentityKey(sessionName, namespace), restoreKey);
 	}
 
-	replace(identities: ManagedSessionRestoreIdentity[], options: { preserveDaemonRestoreKeys?: boolean } = {}): void {
+	replace(identities: ManagedSessionRestoreIdentity[] = [], options: { preserveDaemonRestoreKeys?: boolean } = {}): void {
 		if (!options.preserveDaemonRestoreKeys) this.#daemonRestoreKeys.clear();
 		this.#disabled.clear();
 		for (const identity of identities) this.disable(identity.sessionName, identity.namespace);

--- a/test/agent-browser.managed-session-restore.test.ts
+++ b/test/agent-browser.managed-session-restore.test.ts
@@ -60,6 +60,16 @@ test("managed restore sticky state is isolated per extension instance", () => {
 	assert.equal(first.isDisabled("piab-session", "team"), false);
 });
 
+	test("replace tolerates an absent branch restore identity list (undefined from a pre-upgrade runtime)", () => {
+		const state = new ManagedSessionRestoreState();
+		state.disable("piab-stale", "team");
+		// The version-skew path (new index.js restoring against an old cached runtime.js)
+		// yields `undefined` for managedSessionRestoreDisabledIdentities. Must not throw.
+		state.replace(undefined, { preserveDaemonRestoreKeys: true });
+		assert.equal(state.isDisabled("piab-stale", "team"), false);
+		assert.equal(state.hasDaemonRestoreKey("piab-stale", "team"), false);
+	});
+
 test("branch restore can preserve current-process daemon provenance without persisting it across reload", () => {
 	const state = new ManagedSessionRestoreState();
 	state.recordDaemonRestoreKey("piab-current", "team", null);


### PR DESCRIPTION
## Problem

`restoreBranchBackedState` passes `restoredState.managedSessionRestoreDisabledIdentities` into `ManagedSessionRestoreState.replace()`, which iterates it with `for..of` and throws `identities is not iterable` when the value is absent.

Reported in Pi on `/reload`: the extension entry (`index.js`) is re-read fresh while `lib/runtime.js` remains the **pre-0.2.74** cached build in the same process (Pi loads extensions with a transpiler whose entry import busts the cache, while sibling imports can stay cached). The old `restoreManagedSessionStateFromBranch` never returns the `managedSessionRestoreDisabledIdentities` field, so the new call site passes `undefined` and every `session_start` on reload crashes:

```
Extension ".../agent-browser/index.js" error: identities is not iterable
    at ManagedSessionRestoreState.replace (managed-session-restore.js:77:28)
    at restoreBranchBackedState (index.js:617:32)
```

This is a transient upgrade-path hazard (in-place extension update + reload), but the crash is real and reachable.

## Fix

Default the parameter to `[]` so an absent list is treated as "nothing to restore" instead of crashing.

```ts
replace(identities: ManagedSessionRestoreIdentity[] = [], options: { preserveDaemonRestoreKeys?: boolean } = {}): void
```

## Validation

- New regression test: `replace` with `undefined` no longer throws and clears sticky state.
- `npm test`: 688/693 pass; the 3 failures are pre-existing `verify-package` environment failures (npm pack / publish dry-run), confirmed identical on clean `main`.