### PR TITLE
fix: include build script in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "scripts/config.mjs",
     "scripts/doctor.mjs",
     "scripts/prepare.mjs",
+    "scripts/build.mjs",
     "scripts/agent-browser-capability-baseline.mjs",
     "scripts/platform-smoke.mjs",
     "scripts/platform-smoke",


### PR DESCRIPTION
## Summary

- include `scripts/build.mjs` in the npm package files
- make the published `prepare` lifecycle able to resolve the build script it invokes

Fixes #99

## Validation

- `npm install --ignore-scripts --no-audit --no-fund`
- `npm run build`
- `npm pack --dry-run --json` and verified `scripts/build.mjs` is included
