### PR TITLE
Support private sockets on root Pi hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.4.1 - 2026-08-09
+
+### Fixed
+
+- Root-run Pi hosts can select a private wrapper socket directory with `PI_AGENT_BROWSER_SOCKET_DIR`; the extension validates it and forwards only the corresponding upstream `AGENT_BROWSER_SOCKET_DIR`. Ambient upstream socket overrides remain ignored. This prevents every browser-backed call from failing when uid 0 uses the default root-owned world-writable `/tmp` ancestry.
+
 ## 0.4.0 - 2026-08-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ The doctor checks:
 
 It does **not** edit Pi settings and does **not** run upstream `agent-browser doctor --fix`.
 
+Pi hosts that run as uid 0 should set `PI_AGENT_BROWSER_SOCKET_DIR` to a short absolute directory under private root-owned ancestry, create it with mode `0700`, and keep it owned by the Pi user. The extension validates that directory and forwards it as upstream `AGENT_BROWSER_SOCKET_DIR`; ambient upstream socket overrides remain ignored.
+
 ## Optional package config and web search
 
 `pi-agent-browser-native` also reads package-owned config under Pi-scoped paths:

--- a/extensions/agent-browser/lib/process.ts
+++ b/extensions/agent-browser/lib/process.ts
@@ -44,6 +44,7 @@ const AGENT_BROWSER_ARGS_ENV = "AGENT_BROWSER_ARGS";
 const AGENT_BROWSER_DEFAULT_TIMEOUT_ENV = "AGENT_BROWSER_DEFAULT_TIMEOUT";
 const AGENT_BROWSER_IDLE_TIMEOUT_ENV = "AGENT_BROWSER_IDLE_TIMEOUT_MS";
 const PI_AGENT_BROWSER_PROCESS_TIMEOUT_ENV = "PI_AGENT_BROWSER_PROCESS_TIMEOUT_MS";
+const PI_AGENT_BROWSER_SOCKET_DIR_ENV = "PI_AGENT_BROWSER_SOCKET_DIR";
 const DEFAULT_AGENT_BROWSER_SOCKET_DIR_PREFIX = "/tmp/piab";
 export const SAFE_AGENT_BROWSER_OPERATION_TIMEOUT_MS = 25_000;
 const DEFAULT_AGENT_BROWSER_PROCESS_TIMEOUT_MS = 35_000;
@@ -495,7 +496,7 @@ export async function runAgentBrowserProcess(options: {
 	const explicitSocketDir = processOverrides[AGENT_BROWSER_SOCKET_DIR_ENV];
 	let effectiveEnv = explicitSocketDir === undefined ? { ...processOverrides, [AGENT_BROWSER_SOCKET_DIR_ENV]: undefined } : processOverrides;
 	if (ownedManagedSessionClose) effectiveEnv = { ...effectiveEnv, AGENT_BROWSER_RESTORE: undefined };
-	const requestedSocketDir = explicitSocketDir ?? getAgentBrowserSocketDir();
+	const requestedSocketDir = explicitSocketDir ?? parentEnv[PI_AGENT_BROWSER_SOCKET_DIR_ENV] ?? getAgentBrowserSocketDir();
 	if (requestedSocketDir !== undefined) {
 		const socketDirIsSecure = requestedSocketDir.length > 0 && await ensureAgentBrowserSocketDir(requestedSocketDir);
 		if (signal?.aborted) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-agent-browser-native",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-agent-browser-native",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "bin": {
         "pi-agent-browser-config": "scripts/config.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-agent-browser-native",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "pi extension that exposes agent-browser as a native tool for browser automation",
   "type": "module",
   "author": "Mitch Fultz (https://github.com/fitchmultz)",

--- a/test/agent-browser.process.test.ts
+++ b/test/agent-browser.process.test.ts
@@ -315,6 +315,34 @@ test("agent-browser socket storage rejects unsafe permissions, ancestry, symlink
 	}
 });
 
+test("runAgentBrowserProcess uses the Pi-scoped socket directory without trusting ambient upstream configuration", { concurrency: false }, async () => {
+	const tempDir = await mkdtemp(join(tmpdir(), "pi-agent-browser-socket-config-"));
+	const socketPath = join(tempDir, "socket");
+	try {
+		await writeFakeAgentBrowserBinary(
+			tempDir,
+			`process.stdout.write(JSON.stringify({ success: true, data: { socketDir: process.env.AGENT_BROWSER_SOCKET_DIR ?? null } }));`,
+		);
+		await withPatchedEnv(
+			{
+				AGENT_BROWSER_SOCKET_DIR: join(tempDir, "ignored-upstream-value"),
+				PATH: `${tempDir}${delimiter}${process.env.PATH ?? ""}`,
+				PI_AGENT_BROWSER_SOCKET_DIR: socketPath,
+			},
+			async () => {
+				const result = await runAgentBrowserProcess({ args: ["--version"], cwd: tempDir });
+				assert.equal(result.agentBrowserStarted, true);
+				assert.equal(result.spawnError, undefined);
+				const parsed = await parseAgentBrowserEnvelope(result.stdout);
+				assert.equal((parsed.envelope?.data as { socketDir?: string }).socketDir, socketPath);
+				assert.equal((await stat(socketPath)).mode & 0o777, 0o700);
+			},
+		);
+	} finally {
+		await rm(tempDir, { force: true, recursive: true });
+	}
+});
+
 test("runAgentBrowserProcess fails before spawn for unsafe socket storage", async () => {
 	const tempDir = await mkdtemp(join(tmpdir(), "pi-agent-browser-socket-preflight-"));
 	const markerPath = join(tempDir, "spawned.txt");


### PR DESCRIPTION
## Summary

- add a Pi-scoped `PI_AGENT_BROWSER_SOCKET_DIR` operator setting
- retain the security boundary that ignores ambient upstream `AGENT_BROWSER_SOCKET_DIR`
- validate and forward the selected private directory on every browser subprocess
- add a real `runAgentBrowserProcess` regression and release as 0.4.1

## Why

v0.4.0 rejects `/tmp/piab-0` when Pi runs as uid 0 because root also owns the world-writable `/tmp` ancestor. This made every browser-backed TARS production call fail before spawn.

## Validation

- `npm run verify` (717 tests, command-reference checks)
- focused process suite (31 tests)
- typecheck
