### PR TITLE
Fix Windows empty argument forwarding

### DIFF
--- a/extensions/agent-browser/lib/process.ts
+++ b/extensions/agent-browser/lib/process.ts
@@ -76,7 +76,8 @@ function appendTail(text: string, addition: string, maxChars: number): string {
 }
 
 function quoteWindowsPowerShellArg(value: string): string {
-	return `'${value.replace(/'/g, "''")}'`;
+	// PowerShell drops an empty string when forwarding to a .cmd shim. Pass cmd's quoted-empty token instead.
+	return value.length === 0 ? `'""'` : `'${value.replace(/'/g, "''")}'`;
 }
 
 /** Exported for unit tests that lock Windows launcher argv ordering. */

--- a/test/agent-browser.process.test.ts
+++ b/test/agent-browser.process.test.ts
@@ -209,6 +209,10 @@ test("buildAgentBrowserSpawnCommand uses the npm cmd shim on Windows", () => {
 			args: ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "$agentBrowser = Get-Command agent-browser.cmd -ErrorAction SilentlyContinue; if (-not $agentBrowser) { [Console]::Error.WriteLine('PI_AGENT_BROWSER_COMMAND_NOT_FOUND:agent-browser.cmd'); exit 127 }; & $agentBrowser.Source 'open' '--json' '--session' 'managed' 'https://example.com'"],
 		},
 	);
+	assert.match(
+		buildAgentBrowserSpawnCommand(["--args", "", "--namespace", "", "session", "info"], "win32").args.at(-1) ?? "",
+		/'session' '--args' '""' '--namespace' '""' 'info'$/,
+	);
 	assert.deepEqual(buildAgentBrowserSpawnCommand(["--version"], "darwin"), { command: "agent-browser", args: ["--version"] });
 });
 


### PR DESCRIPTION
## Summary
- preserve empty arguments when PowerShell invokes the agent-browser .cmd shim
- cover empty --args and --namespace values in the Windows spawn-command regression test

## Verification
- focused Windows launcher regression test passes
- TypeScript typecheck passes
- build compilation passes
- fresh pi-maos session successfully opens a local URL with sessionMode=fresh

## Notes
The broader process test file still has unrelated existing Windows/environment failures.