### PR TITLE
Fix Windows launcher dropping empty argv values

### DIFF
--- a/extensions/agent-browser/lib/executable-path.ts
+++ b/extensions/agent-browser/lib/executable-path.ts
@@ -1,19 +1,28 @@
-import { constants as fsConstants } from "node:fs";
-import { access, stat } from "node:fs/promises";
+import { accessSync, constants as fsConstants, statSync } from "node:fs";
 import { delimiter, join } from "node:path";
 
-export async function executableExistsOnPath(command: string): Promise<boolean> {
+/**
+ * First PATH/PATHEXT candidate for `command` as an existing regular file, or
+ * `undefined` when none is found. Mirrors `executableExistsOnPath` but returns
+ * the resolved path so callers can spawn a discovered launchable directly
+ * instead of re-deriving it.
+ */
+export function resolveExecutableOnPathSync(command: string, pathEnv: string | undefined = process.env.PATH): string | undefined {
 	const extensions = process.platform === "win32" ? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";").filter(Boolean) : [""];
-	for (const directory of (process.env.PATH ?? "").split(delimiter).filter(Boolean)) {
+	for (const directory of (pathEnv ?? "").split(delimiter).filter(Boolean)) {
 		for (const extension of extensions) {
 			try {
 				const candidate = join(directory, `${command}${extension}`);
-				await access(candidate, fsConstants.X_OK);
-				if ((await stat(candidate)).isFile()) return true;
+				accessSync(candidate, fsConstants.X_OK);
+				if (statSync(candidate).isFile()) return candidate;
 			} catch {
 				// Try the next PATH candidate.
 			}
 		}
 	}
-	return false;
+	return undefined;
+}
+
+export async function executableExistsOnPath(command: string): Promise<boolean> {
+	return resolveExecutableOnPathSync(command) !== undefined;
 }

--- a/extensions/agent-browser/lib/process.ts
+++ b/extensions/agent-browser/lib/process.ts
@@ -1,10 +1,12 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { readFileSync, statSync } from "node:fs";
 import { lstat, mkdir, readdir } from "node:fs/promises";
-import { dirname, isAbsolute, join } from "node:path";
+import { basename, dirname, isAbsolute, join } from "node:path";
 import { env as processEnv, platform as processPlatform } from "node:process";
 
 import { parseArgvDescriptor } from "./argv-descriptor.js";
+import { resolveExecutableOnPathSync } from "./executable-path.js";
 import { needsManagedSession } from "./command-policy.js";
 import { isKnownCommandToken } from "./command-taxonomy.js";
 import {
@@ -173,9 +175,71 @@ export function pinAgentBrowserFileAccessDisabled(args: string[], wrapperCompati
 	return ["--args", browserArgs, "--allow-file-access", "false", ...filtered];
 }
 
-export function buildAgentBrowserSpawnCommand(args: string[], platform: NodeJS.Platform = processPlatform): { command: string; args: string[] } {
+/**
+ * Resolves the native agent-browser Windows binary, scoped to the PATH the
+ * spawned subprocess itself will run with (`pathEnv`) rather than the wrapper's
+ * own process PATH, so environment overrides and test harnesses that prepend a
+ * fake shim are honored.
+ */
+function resolveWindowsAgentBrowserNativeExecutable(pathEnv: string | undefined): string | undefined {
+	const binaryName = `agent-browser-${processPlatform}-${process.arch}.exe`;
+	if (!/^agent-browser-win32-(x64|arm64)\.exe$/i.test(binaryName)) return undefined;
+	const shimPath = resolveExecutableOnPathSync("agent-browser", pathEnv);
+	if (!shimPath) return undefined;
+	const shimDir = dirname(shimPath);
+	if (/\.cmd$/i.test(shimPath)) {
+		try {
+			const nativePath = extractWindowsCmdShimExe(readFileSync(shimPath, "utf8"), shimDir, binaryName);
+			if (nativePath) return nativePath;
+		} catch {
+			// Fall through to the derived npm layout below.
+		}
+	}
+	// Standard npm global layout: the shim lives in the npm bin dir and the native
+	// binary sits in its package next door.
+	const derived = join(shimDir, "node_modules", "agent-browser", "bin", binaryName);
+	try {
+		return statSync(derived).isFile() ? derived : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/** Pull the quoted native `.exe` target out of an npm-generated `agent-browser.cmd` shim. */
+export function extractWindowsCmdShimExe(shimText: string, shimDir: string, expectedBinaryName: string): string | undefined {
+	for (const line of shimText.split(/\r?\n/)) {
+		const match = /"([^"]+\.exe)"/i.exec(line);
+		if (!match) continue;
+		let raw = match[1] as string;
+		if (raw.startsWith("%~dp0")) raw = join(shimDir, raw.slice("%~dp0".length));
+		else if (!isAbsolute(raw)) raw = join(shimDir, raw);
+		if (isAbsolute(raw) && basename(raw).toLowerCase() === expectedBinaryName.toLowerCase()) return raw;
+	}
+	return undefined;
+}
+
+export interface WindowsNativeSpawnOptions {
+	/** PATH the spawned subprocess will run with. Native Windows binary resolution scopes to it. */
+	path?: string;
+	/** Test seam: override native Windows binary resolution (keyed by the effective PATH). */
+	resolveWindowsNativeBinary?: (pathEnv: string | undefined) => string | undefined;
+}
+
+export function buildAgentBrowserSpawnCommand(
+	args: string[],
+	platform: NodeJS.Platform = processPlatform,
+	options: WindowsNativeSpawnOptions = {},
+): { command: string; args: string[] } {
 	if (platform !== "win32") {
 		return { command: "agent-browser", args };
+	}
+	const pathEnv = options.path ?? process.env.PATH;
+	const nativeBinary = (options.resolveWindowsNativeBinary ?? resolveWindowsAgentBrowserNativeExecutable)(pathEnv);
+	if (nativeBinary) {
+		// Direct native spawn preserves empty argv values (e.g. `--namespace ""`),
+		// which the PowerShell -> .cmd shim route drops and thereby shifts every
+		// following argument. Pass argv through untouched.
+		return { command: nativeBinary, args };
 	}
 	const invocationArgs = reorderWindowsLeadingGlobalArgs(args).map(quoteWindowsPowerShellArg).join(" ");
 	const commandLine = [
@@ -691,7 +755,7 @@ export async function runAgentBrowserProcess(options: {
 			resolve({ aborted: false, agentBrowserStarted: false, exitCode: 1, spawnError: new Error(spawnPolicyError), stderr: "", stdout: "", timedOut: false });
 			return;
 		}
-		const spawnCommand = buildAgentBrowserSpawnCommand(pinAgentBrowserFileAccessDisabled(args, ownedManagedSessionCompatibilityEnv.AGENT_BROWSER_USER_AGENT, preserveAttachedBrowserSession));
+		const spawnCommand = buildAgentBrowserSpawnCommand(pinAgentBrowserFileAccessDisabled(args, ownedManagedSessionCompatibilityEnv.AGENT_BROWSER_USER_AGENT, preserveAttachedBrowserSession), processPlatform, { path: childEnv.PATH });
 		const child = spawn(spawnCommand.command, spawnCommand.args, {
 			cwd,
 			env: childEnv,

--- a/test/agent-browser.process.test.ts
+++ b/test/agent-browser.process.test.ts
@@ -25,6 +25,7 @@ import { buildProcessStartIdentityCommand, buildProcessStartIdentityCommands, no
 import {
 	buildAgentBrowserProcessEnv,
 	buildAgentBrowserSpawnCommand,
+	extractWindowsCmdShimExe,
 	ensureAgentBrowserSocketDir,
 	getAgentBrowserProcessTimeoutMs,
 	getAgentBrowserSocketDir,
@@ -220,15 +221,45 @@ process.stdout.write(JSON.stringify({ success: true, data: { allowFileAccessEnv:
 });
 
 
-test("buildAgentBrowserSpawnCommand uses the npm cmd shim on Windows", () => {
+test("buildAgentBrowserSpawnCommand prefers the native Windows binary and passes argv verbatim", () => {
+	const nativeArgs = ["--json", "--namespace", "", "--session", "managed", "session", "info"];
 	assert.deepEqual(
-		buildAgentBrowserSpawnCommand(["--json", "--session", "managed", "open", "https://example.com"], "win32"),
+		buildAgentBrowserSpawnCommand(nativeArgs, "win32", { resolveWindowsNativeBinary: () => "C:\\fake-dir\\agent-browser-win32-x64.exe" }),
+		{ command: "C:\\fake-dir\\agent-browser-win32-x64.exe", args: nativeArgs },
+	);
+	assert.deepEqual(buildAgentBrowserSpawnCommand(["--version"], "darwin"), { command: "agent-browser", args: ["--version"] });
+});
+
+test("buildAgentBrowserSpawnCommand keeps the empty namespace through the native Windows binary", () => {
+	// Regression: PowerShell -> .cmd re-quoting drops the empty `--namespace ""`
+	// operand and shifts `--session`'s value into the command position, so every
+	// wrapper-owned probe and navigation on Windows failed. A direct native spawn
+	// must preserve every operand, including empty strings, in argv position.
+	const nativeArgs = ["--json", "--namespace", "", "--session", "managed", "session", "info"];
+	assert.deepEqual(
+		buildAgentBrowserSpawnCommand(nativeArgs, "win32", { resolveWindowsNativeBinary: () => "C:\\fake-dir\\agent-browser-win32-x64.exe" }).args,
+		nativeArgs,
+	);
+});
+
+test("buildAgentBrowserSpawnCommand falls back to the npm cmd shim via PowerShell when the native binary is unresolvable", () => {
+	assert.deepEqual(
+		buildAgentBrowserSpawnCommand(["--json", "--session", "managed", "open", "https://example.com"], "win32", { resolveWindowsNativeBinary: () => undefined }),
 		{
 			command: "powershell.exe",
 			args: ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "$agentBrowser = Get-Command agent-browser.cmd -ErrorAction SilentlyContinue; if (-not $agentBrowser) { [Console]::Error.WriteLine('PI_AGENT_BROWSER_COMMAND_NOT_FOUND:agent-browser.cmd'); exit 127 }; & $agentBrowser.Source 'open' '--json' '--session' 'managed' 'https://example.com'"],
 		},
 	);
-	assert.deepEqual(buildAgentBrowserSpawnCommand(["--version"], "darwin"), { command: "agent-browser", args: ["--version"] });
+});
+
+test("extractWindowsCmdShimExe resolves the quoted native binary target from an npm cmd shim", { skip: process.platform !== "win32" }, () => {
+	const shimDir = "C:\\Users\\test\\npm";
+	assert.equal(
+		extractWindowsCmdShimExe('@ECHO off\n"%~dp0node_modules\\agent-browser\\bin\\agent-browser-win32-x64.exe" %*', shimDir, "agent-browser-win32-x64.exe"),
+		"C:\\Users\\test\\npm\\node_modules\\agent-browser\\bin\\agent-browser-win32-x64.exe",
+	);
+	assert.equal(extractWindowsCmdShimExe('@ECHO off\n"%~dp0node_modules\\agent-browser\\bin\\agent-browser-win32-x64.exe" %*', shimDir, "agent-browser-win32-arm64.exe"), undefined);
+	assert.equal(extractWindowsCmdShimExe("echo not a shim", shimDir, "agent-browser-win32-x64.exe"), undefined);
 });
 
 test("process start identity commands use absolute POSIX fallbacks and native PowerShell on Windows", async () => {


### PR DESCRIPTION
PowerShell re-quotes argv when invoking the npm agent-browser.cmd shim, dropping empty-string operands such as the wrapper-owned `--namespace ""` default and shifting every argument that follows. The managed-session daemon probe (`session info`) then received a corrupted command tail (`Unknown command: default`) and every `open <url>` navigation failed on Windows.

Spawn the native `agent-browser-<platform>-<arch>.exe` directly on Windows when its resolved binary is found: Node's spawn() builds a CreateProcess-style command line that preserves every argv value exactly as typed, including empty strings. The legacy PowerShell -> cmd shim route remains as a fallback when the native binary cannot be resolved.

Native-binary resolution is scoped to the PATH the child process will run with (the wrapper's effective subprocess env PATH), so callers that prepend a different shim or fake binary to PATH are honored rather than bypassed.

The empty-argument band-aid in reorderWindowsLeadingGlobalArgs (skipping empty --args/--namespace in leading position) is no longer needed on the native path but is retained for the PowerShell fallback.