### PR TITLE
fix: clarify electron list timeout guidance

### DIFF
--- a/extensions/agent-browser/lib/orchestration/input-plan.ts
+++ b/extensions/agent-browser/lib/orchestration/input-plan.ts
@@ -226,7 +226,9 @@ export function resolveAgentBrowserInput(options: {
 	const timeoutMsError = params.timeoutMs !== undefined && (typeof params.timeoutMs !== "number" || !Number.isSafeInteger(params.timeoutMs) || params.timeoutMs <= 0)
 		? "timeoutMs must be a positive integer when provided."
 		: compiledElectron && params.timeoutMs !== undefined
-			? "Use electron.timeoutMs for electron actions; top-level timeoutMs applies only to browser CLI subprocess calls."
+			? compiledElectron.action === "list"
+				? "electron.list does not accept a timeout; omit top-level timeoutMs."
+				: "Use electron.timeoutMs for electron actions; top-level timeoutMs applies only to browser CLI subprocess calls."
 			: compiledScript && params.timeoutMs !== undefined && params.timeoutMs > AGENT_BROWSER_SCRIPT_MAX_TIMEOUT_MS
 				? `script timeoutMs must be ${AGENT_BROWSER_SCRIPT_MAX_TIMEOUT_MS} or less.`
 				: undefined;

--- a/test/agent-browser.extension-electron-lifecycle.test.ts
+++ b/test/agent-browser.extension-electron-lifecycle.test.ts
@@ -170,6 +170,12 @@ process.stdout.write(JSON.stringify({ success: true, data: "should not run" }));
 			assert.equal(listWithLaunchField.isError, true);
 			assert.match(listWithLaunchField.content[0]?.text ?? "", /electron\.list only supports query and maxResults; remove electron\.appName/);
 
+			const listWithTopLevelTimeout = await executeRegisteredTool(harness.tool, harness.ctx, {
+				electron: { action: "list" },
+				timeoutMs: 1_000,
+			});
+			assert.equal(listWithTopLevelTimeout.isError, true);
+			assert.match(listWithTopLevelTimeout.content[0]?.text ?? "", /electron\.list does not accept a timeout; omit top-level timeoutMs/);
 			const missingLaunchTarget = await executeRegisteredTool(harness.tool, harness.ctx, { electron: { action: "launch" } });
 			assert.equal(missingLaunchTarget.isError, true);
 			assert.match(missingLaunchTarget.content[0]?.text ?? "", /electron\.launch requires exactly one of appPath, appName, bundleId, or executablePath/);


### PR DESCRIPTION
## What changed

Return an action-specific validation error when top-level `timeoutMs` is passed with `electron.list`.

## Why

`electron.list` has no timeout input, but the previous error incorrectly told callers to use `electron.timeoutMs`, which that action also rejects.

## Validation

- `npx tsx --test --test-name-pattern='accepts action-specific electron schema' test/agent-browser.extension-electron-lifecycle.test.ts`
- `npm run typecheck`
