### PR TITLE
fix: hide semanticAction.values from non-select schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Split `semanticAction` schema into `select` vs `check|click|fill` unions so model-facing params no longer expose `values` on non-select actions (reduces invalid `semanticAction.values is only supported for select actions` loops). Tightened `stdin` description to state it is never valid with open/snapshot/click/fill.
+
 ## 0.4.5 - 2026-08-18
 
 ### Fixed

--- a/extensions/agent-browser/lib/input-modes/params.ts
+++ b/extensions/agent-browser/lib/input-modes/params.ts
@@ -12,7 +12,6 @@ import {
 	AGENT_BROWSER_JOB_STEP_ACTIONS,
 	AGENT_BROWSER_JOB_TYPE_DELAYED_TEXT_MAX_CHARACTERS,
 	AGENT_BROWSER_QA_LOAD_STATES,
-	AGENT_BROWSER_SEMANTIC_ACTIONS,
 	AGENT_BROWSER_SEMANTIC_LOCATORS,
 	DEFAULT_SESSION_MODE,
 	SOURCE_LOOKUP_MAX_WORKSPACE_FILES,
@@ -35,18 +34,30 @@ export function createAgentBrowserParamsSchema(
 			minItems: 1,
 		}),
 	),
+	// Split select vs check/click/fill so models do not see `values` on non-select actions.
 	semanticAction: Type.Optional(
-		Type.Object({
-			action: StringEnum(AGENT_BROWSER_SEMANTIC_ACTIONS),
-			locator: Type.Optional(StringEnum(AGENT_BROWSER_SEMANTIC_LOCATORS, { description: "Locator for check/click/fill; select supports role or label." })),
-			value: Type.Optional(Type.String({ description: "Locator value or one select option; for select by label, this is the label text." })),
-			values: Type.Optional(Type.Array(Type.String(), { description: "Select options; required for select by label.", minItems: 1 })),
-			selector: Type.Optional(Type.String({ description: "Direct selector or @ref." })),
-			text: Type.Optional(Type.String({ description: "Fill text." })),
-			role: Type.Optional(Type.String({ description: "Role locator; alternative to value." })),
-			name: Type.Optional(Type.String({ description: "Accessible name." })),
-			session: Type.Optional(Type.String({ description: "Upstream session name." })),
-		}, { additionalProperties: false, description: "Stable locator or direct-selector action." }),
+		Type.Union([
+			Type.Object({
+				action: StringEnum(["select"]),
+				locator: Type.Optional(StringEnum(AGENT_BROWSER_SEMANTIC_LOCATORS, { description: "Locator for select by role or label." })),
+				value: Type.Optional(Type.String({ description: "One select option, or label text for locator=label." })),
+				values: Type.Optional(Type.Array(Type.String(), { description: "Select option values.", minItems: 1 })),
+				selector: Type.Optional(Type.String({ description: "Direct selector or @ref." })),
+				role: Type.Optional(Type.String({ description: "Role locator; alternative to value." })),
+				name: Type.Optional(Type.String({ description: "Accessible name." })),
+				session: Type.Optional(Type.String({ description: "Upstream session name." })),
+			}, { additionalProperties: false }),
+			Type.Object({
+				action: StringEnum(["check", "click", "fill"]),
+				locator: Type.Optional(StringEnum(AGENT_BROWSER_SEMANTIC_LOCATORS, { description: "Locator for check/click/fill." })),
+				value: Type.Optional(Type.String({ description: "Locator value." })),
+				selector: Type.Optional(Type.String({ description: "Direct selector or @ref." })),
+				text: Type.Optional(Type.String({ description: "Fill text." })),
+				role: Type.Optional(Type.String({ description: "Role locator; alternative to value." })),
+				name: Type.Optional(Type.String({ description: "Accessible name." })),
+				session: Type.Optional(Type.String({ description: "Upstream session name." })),
+			}, { additionalProperties: false }),
+		], { description: "Stable locator or direct-selector action. values only with action=select." }),
 	),
 	qa: Type.Optional(
 		Type.Union([
@@ -157,7 +168,7 @@ export function createAgentBrowserParamsSchema(
 			),
 		}, { additionalProperties: false, description: "Constrained multi-step batch." }),
 	),
-	stdin: Type.Optional(Type.String({ description: "Raw stdin for batch, eval --stdin, or auth save --password-stdin; unavailable with structured modes and electron." })),
+	stdin: Type.Optional(Type.String({ description: "Only for batch, eval --stdin, or auth save --password-stdin. Never with open/snapshot/click/fill or structured modes/electron." })),
 	outputPath: Type.Optional(Type.String({ description: "Workspace-relative or absolute result-data path; keep it distinct from screenshot, download, recording, and other browser artifact destinations.", minLength: 1 })),
 	timeoutMs: Type.Optional(Type.Integer({ description: "Wrapper timeout in ms; exceed explicit waits. Electron uses electron.timeoutMs.", minimum: 1 })),
 	sessionMode: Type.Optional(

--- a/test/agent-browser.extension-validation.test.ts
+++ b/test/agent-browser.extension-validation.test.ts
@@ -313,6 +313,8 @@ test("agentBrowserExtension rejects unsupported public schema fields", () => {
 	assert.equal(Check(schema, { args: ["open", "https://example.test/"], outputPath: "" }), false);
 	assert.equal(Check(schema, { args: ["open", "https://example.test/"], timeoutMs: 0 }), false);
 	assert.equal(Check(schema, { semanticAction: { action: "click", locator: "role", role: "button", name: "Open" } }), true);
+	assert.equal(Check(schema, { semanticAction: { action: "click", locator: "text", value: "Open", values: ["nope"] } }), false);
+	assert.equal(Check(schema, { semanticAction: { action: "select", selector: "#flavor", value: "chocolate" } }), true);
 	assert.equal(Check(schema, { sourceLookup: { selector: "main" } }), true);
 	assert.equal(Check(schema, { networkSourceLookup: { namespace: "review", url: "https://example.test/api" } }), true);
 	assert.equal(Check(schema, { job: { steps: [{ action: "open", url: "https://example.test/" }] } }), true);


### PR DESCRIPTION
## Summary

Models keep calling `agent_browser` with `semanticAction.values` on non-select actions (and sometimes `stdin` on `open`), which fails validation and loops:

`semanticAction.values is only supported for select actions.`

Root cause: the model-facing schema exposed `values` on every `semanticAction` action. This splits `semanticAction` into a union:

- `action: "select"` — may include `value` / `values`
- `action: "check" | "click" | "fill"` — no `values` field

Also tightens the `stdin` description so it is clear it is only for `batch` / `eval --stdin` / `auth save --password-stdin`.

## Test plan

- [x] `npm run build`
- [x] `tsx --test test/agent-browser.schema.test.ts test/agent-browser.extension-validation.test.ts` (35 pass)
- [x] Schema rejects `{ action: "click", ..., values: ["nope"] }`
- [x] Schema still accepts select and click/fill without values

## Risks

Low. Runtime validation already rejected non-select `values`; this only removes the field from the model-facing schema so models stop emitting it. No behavior change for valid calls.