### PR TITLE
fix(posix): resolve `ps` through `PATH` for policy locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.6.6 - 2026-09-05
+
 ### Fixed
 
 - Resolve POSIX process identity with `ps` from `PATH` when the system paths are unavailable, so managed-session locks work on NixOS-style installations. Keep system-path preference and reject malformed identity output. Thanks to @GodTamIt for the report and fix in #142 / #143.

--- a/extensions/agent-browser/lib/managed-session-policy-lock.ts
+++ b/extensions/agent-browser/lib/managed-session-policy-lock.ts
@@ -42,6 +42,8 @@ export interface ManagedSessionPolicyLock {
 	release: () => Promise<void>;
 }
 
+type ProcessStartIdentityReader = (pid: number) => Promise<string | undefined>;
+
 function getCoordinationDirectory(platform: NodeJS.Platform = process.platform): string {
 	if (platform !== "win32") {
 		const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
@@ -200,7 +202,10 @@ async function readClaims(basePath: string): Promise<PolicyLockClaim[] | undefin
 	return claims;
 }
 
-async function ownerAlive(owner: PolicyLockOwner | LegacyPolicyLockOwner): Promise<boolean | undefined> {
+async function ownerAlive(
+	owner: PolicyLockOwner | LegacyPolicyLockOwner,
+	readStartIdentity: ProcessStartIdentityReader,
+): Promise<boolean | undefined> {
 	try {
 		process.kill(owner.pid, 0);
 	} catch (error) {
@@ -208,7 +213,7 @@ async function ownerAlive(owner: PolicyLockOwner | LegacyPolicyLockOwner): Promi
 		if (code === "ESRCH") return false;
 		if (code !== "EPERM") return undefined;
 	}
-	const current = await readProcessStartIdentity(owner.pid);
+	const current = await readStartIdentity(owner.pid);
 	return current === undefined ? undefined : processStartIdentitiesMatch(owner.startIdentity, current);
 }
 
@@ -248,7 +253,7 @@ async function removeLegacyBridgeOwnedBy(path: string, token: string): Promise<b
 	return true;
 }
 
-async function cleanDeadPolicyArtifacts(directory: string): Promise<void> {
+async function cleanDeadPolicyArtifacts(directory: string, readStartIdentity: ProcessStartIdentityReader): Promise<void> {
 	let names: string[];
 	try { names = await readdir(directory); } catch { return; }
 	for (const name of names.filter((candidate) =>
@@ -259,7 +264,7 @@ async function cleanDeadPolicyArtifacts(directory: string): Promise<void> {
 		|| candidate.includes(".lock-v3.candidate-"))) {
 		const path = join(directory, name);
 		const owner = await readLegacyBridgeOwner(path);
-		if (owner && await ownerAlive(owner) === false) await rm(path, { force: true, recursive: true }).catch(() => undefined);
+		if (owner && await ownerAlive(owner, readStartIdentity) === false) await rm(path, { force: true, recursive: true }).catch(() => undefined);
 	}
 }
 
@@ -275,6 +280,7 @@ async function hasLegacyV2Contender(path: string): Promise<boolean | undefined> 
 async function acquireLegacyPolicyBridge(options: {
 	deadline: number;
 	owner: PolicyLockOwner;
+	readStartIdentity: ProcessStartIdentityReader;
 	signal?: AbortSignal;
 	sessionName: string;
 	namespace?: string;
@@ -303,7 +309,7 @@ async function acquireLegacyPolicyBridge(options: {
 			}
 			const observed = await readLegacyBridgeOwner(path);
 			if (!observed) return undefined;
-			if (observed.version === 3 && await ownerAlive(observed) === false) {
+			if (observed.version === 3 && await ownerAlive(observed, options.readStartIdentity) === false) {
 				if (await removeLegacyBridgeOwnedBy(path, observed.token)) continue;
 			}
 			if (Date.now() >= options.deadline) return undefined;
@@ -338,17 +344,24 @@ function waitForRetry(signal?: AbortSignal): Promise<void> {
 
 export async function acquireManagedSessionPolicyLock(options: {
 	namespace?: string;
+	processStartIdentityReader?: ProcessStartIdentityReader;
 	sessionName: string;
 	signal?: AbortSignal;
 	timeoutMs?: number;
 }): Promise<ManagedSessionPolicyLock | undefined> {
 	if (options.signal?.aborted) return undefined;
+	const readStartIdentity = options.processStartIdentityReader ?? readProcessStartIdentity;
 	const platform = process.platform;
 	const directory = getCoordinationDirectory(platform);
 	if (!await ensureCoordinationDirectory(directory, platform)) return undefined;
 	const basePath = getManagedSessionPolicyLockPath(options.sessionName, options.namespace);
 	const token = randomUUID();
-	const startIdentity = await readProcessStartIdentity(process.pid);
+	let startIdentity: string | undefined;
+	try {
+		startIdentity = await readStartIdentity(process.pid);
+	} catch {
+		return undefined;
+	}
 	if (!startIdentity) return undefined;
 	const owner = { pid: process.pid, startIdentity, token, version: 3 } satisfies PolicyLockOwner;
 	const candidatePath = `${basePath}.candidate-${token}`;
@@ -380,7 +393,7 @@ export async function acquireManagedSessionPolicyLock(options: {
 			let blocked = false;
 			for (const claim of claims) {
 				if (claim.owner.token === token || !claimPrecedes(claim, ownClaim)) continue;
-				const alive = await ownerAlive(claim.owner);
+				const alive = await ownerAlive(claim.owner, readStartIdentity);
 				if (alive === false) {
 					await removeClaimOwnedBy(claim.path, claim.owner.token);
 					continue;
@@ -389,10 +402,11 @@ export async function acquireManagedSessionPolicyLock(options: {
 				break;
 			}
 			if (!blocked) {
-				await cleanDeadPolicyArtifacts(directory);
+				await cleanDeadPolicyArtifacts(directory, readStartIdentity);
 				legacyBridge = await acquireLegacyPolicyBridge({
 					deadline,
 					owner,
+					readStartIdentity,
 					signal: options.signal,
 					sessionName: options.sessionName,
 					namespace: options.namespace,

--- a/extensions/agent-browser/lib/orchestration/browser-run/managed-session-daemon-policy.ts
+++ b/extensions/agent-browser/lib/orchestration/browser-run/managed-session-daemon-policy.ts
@@ -82,7 +82,7 @@ export async function acquireOwnedManagedSessionDaemonPolicy(options: {
 		return signal?.aborted
 			? {}
 			: {
-				error: "Managed-session policy coordination is unavailable or busy. Retry after the current operation finishes, repair the private policy-lock directory, and on POSIX verify that /bin/ps or /usr/bin/ps is available.",
+				error: "Managed-session policy coordination is unavailable or busy. Retry after the current operation finishes, repair the private policy-lock directory, and on POSIX verify that /bin/ps, /usr/bin/ps, or ps through PATH is available.",
 			};
 	}
 

--- a/extensions/agent-browser/lib/process-identity.ts
+++ b/extensions/agent-browser/lib/process-identity.ts
@@ -10,6 +10,13 @@ export interface ProcessStartIdentityCommand {
 	file: string;
 }
 
+export type ProcessStartIdentityExecFile = (
+	file: string,
+	args: string[],
+	options: { timeout: number },
+	callback: (error: Error | null, stdout: string) => void,
+) => unknown;
+
 export function buildProcessStartIdentityCommand(
 	pid: number,
 	platform: NodeJS.Platform = process.platform,
@@ -43,20 +50,34 @@ export function buildProcessStartIdentityCommands(
 	if (!primary) return [];
 	return platform === "win32"
 		? [primary]
-		: [primary, ...(platform === "android" ? [{ ...primary, file: "/bin/ps" }, { ...primary, file: "/usr/bin/ps" }] : [{ ...primary, file: "/usr/bin/ps" }])];
+		: [
+			primary,
+			...(platform === "android"
+				? [{ ...primary, file: "/bin/ps" }, { ...primary, file: "/usr/bin/ps" }]
+				: [{ ...primary, file: "/usr/bin/ps" }, { ...primary, file: "ps" }]),
+		];
 }
 
 export function normalizeProcessStartIdentity(stdout: string): string | undefined {
-	return stdout.trim().replace(/\s+/g, " ") || undefined;
+	const trimmed = stdout.trim();
+	if (!trimmed || trimmed.includes("\0") || /[\r\n]/.test(trimmed)) return undefined;
+	return trimmed.replace(/\s+/g, " ");
 }
 
 let currentProcessStartIdentityPromise: Promise<string | undefined> | undefined;
 
-async function executeProcessStartIdentityCommand(command: ProcessStartIdentityCommand): Promise<string | undefined> {
+export async function executeProcessStartIdentityCommand(
+	command: ProcessStartIdentityCommand,
+	execute: ProcessStartIdentityExecFile = execFile,
+): Promise<string | undefined> {
 	return await new Promise((resolve) => {
-		execFile(command.file, command.args, { timeout: PROCESS_START_IDENTITY_TIMEOUT_MS }, (error, stdout) => {
-			resolve(error ? undefined : normalizeProcessStartIdentity(stdout));
-		});
+		try {
+			execute(command.file, command.args, { timeout: PROCESS_START_IDENTITY_TIMEOUT_MS }, (error, stdout) => {
+				resolve(error || typeof stdout !== "string" ? undefined : normalizeProcessStartIdentity(stdout));
+			});
+		} catch {
+			resolve(undefined);
+		}
 	});
 }
 
@@ -65,8 +86,10 @@ export async function resolveProcessStartIdentityFromCommands(
 	execute: (command: ProcessStartIdentityCommand) => Promise<string | undefined> = executeProcessStartIdentityCommand,
 ): Promise<string | undefined> {
 	for (const command of commands) {
-		const identity = await execute(command);
-		if (identity) return identity;
+		try {
+			const identity = await execute(command);
+			if (identity) return identity;
+		} catch {}
 	}
 	return undefined;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-agent-browser-native",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-agent-browser-native",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "MIT",
       "bin": {
         "pi-agent-browser-config": "scripts/config.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-agent-browser-native",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "pi extension that exposes agent-browser as a native tool for browser automation",
   "type": "module",
   "author": "Mitch Fultz (https://github.com/fitchmultz)",

--- a/test/agent-browser.managed-session-policy-lock.test.ts
+++ b/test/agent-browser.managed-session-policy-lock.test.ts
@@ -16,6 +16,7 @@ import {
 	getLegacyManagedSessionPolicyLockPath,
 	getManagedSessionPolicyLockPath,
 } from "../extensions/agent-browser/lib/managed-session-policy-lock.js";
+import { buildProcessStartIdentityCommands, resolveProcessStartIdentityFromCommands } from "../extensions/agent-browser/lib/process-identity.js";
 
 const sessionName = `piab-policy-lock-${process.pid}`;
 const lockBasePath = getManagedSessionPolicyLockPath(sessionName);
@@ -45,6 +46,23 @@ test.afterEach(async () => {
 	await rm(legacyLockPath, { force: true, recursive: true });
 	await rm(legacyCandidatePath, { force: true, recursive: true });
 	await rm(testOrphanPath, { force: true, recursive: true });
+});
+
+test("managed session policy lock acquires with a process identity resolved through PATH fallback", async () => {
+	const attempts: string[] = [];
+	const lock = await acquireManagedSessionPolicyLock({
+		processStartIdentityReader: async (pid) => await resolveProcessStartIdentityFromCommands(
+			buildProcessStartIdentityCommands(pid, "linux"),
+			async (command) => {
+				attempts.push(command.file);
+				return command.file === "ps" ? "Sun Aug 3 00:00:00 2026" : undefined;
+			},
+		),
+		sessionName,
+	});
+	assert.ok(lock);
+	assert.deepEqual(attempts, ["/bin/ps", "/usr/bin/ps", "ps"]);
+	await lock.release();
 });
 
 test("managed session policy lock waits asynchronously and releases only its immutable claim", async () => {

--- a/test/agent-browser.process.test.ts
+++ b/test/agent-browser.process.test.ts
@@ -21,7 +21,7 @@ import {
 	ManagedSessionRestoreState,
 	withOwnedManagedSessionContext,
 } from "../extensions/agent-browser/lib/managed-session-restore.js";
-import { buildProcessStartIdentityCommand, buildProcessStartIdentityCommands, normalizeProcessStartIdentity, processStartIdentitiesMatch, resolveProcessStartIdentityFromCommands } from "../extensions/agent-browser/lib/process-identity.js";
+import { buildProcessStartIdentityCommand, buildProcessStartIdentityCommands, executeProcessStartIdentityCommand, normalizeProcessStartIdentity, processStartIdentitiesMatch, resolveProcessStartIdentityFromCommands } from "../extensions/agent-browser/lib/process-identity.js";
 import {
 	buildAgentBrowserProcessEnv,
 	buildAgentBrowserSpawnCommand,
@@ -237,29 +237,72 @@ test("buildAgentBrowserSpawnCommand uses the npm cmd shim on Windows", () => {
 	assert.deepEqual(buildAgentBrowserSpawnCommand(["--version"], "darwin"), { command: "agent-browser", args: ["--version"] });
 });
 
-test("process start identity commands use absolute POSIX fallbacks and native PowerShell on Windows", async () => {
+test("process start identity commands preserve platform-specific candidate order and arguments", () => {
 	const posixCommands = buildProcessStartIdentityCommands(123, "linux");
-	assert.deepEqual(posixCommands.map((command) => command.file), ["/bin/ps", "/usr/bin/ps"]);
-	const attempts: string[] = [];
-	assert.equal(await resolveProcessStartIdentityFromCommands(posixCommands, async (command) => {
-		attempts.push(command.file);
-		return command.file === "/usr/bin/ps" ? "fallback-identity" : undefined;
-	}), "fallback-identity");
-	assert.deepEqual(attempts, ["/bin/ps", "/usr/bin/ps"]);
+	assert.deepEqual(posixCommands.map((command) => command.file), ["/bin/ps", "/usr/bin/ps", "ps"]);
+	assert.deepEqual(posixCommands.map((command) => command.args), Array(3).fill(["-p", "123", "-o", "lstart="]));
 	assert.deepEqual(
 		buildProcessStartIdentityCommands(123, "android").map((command) => command.file),
 		[join(dirname(process.execPath), "ps"), "/bin/ps", "/usr/bin/ps"],
 	);
-	const windows = buildProcessStartIdentityCommand(123, "win32");
+	const windowsCommands = buildProcessStartIdentityCommands(123, "win32");
+	assert.equal(windowsCommands.length, 1);
+	const windows = windowsCommands[0];
 	assert.match(windows?.file ?? "", /(?:^|[\\/])powershell\.exe$/i);
 	assert.equal(win32.isAbsolute(windows?.file ?? ""), true);
 	assert.ok(windows?.args.includes("-NonInteractive"));
 	assert.match(windows?.args.at(-1) ?? "", /Get-Process -Id 123/);
 	assert.match(windows?.args.at(-1) ?? "", /win32-powershell-ticks-v1:/);
 	assert.equal(buildProcessStartIdentityCommand(0, "win32"), undefined);
-	assert.equal(normalizeProcessStartIdentity("  638000000000000000\r\n"), "638000000000000000");
+	assert.equal(normalizeProcessStartIdentity("  Sun Aug  3 00:00:00 2026\r\n"), "Sun Aug 3 00:00:00 2026");
 	assert.equal(processStartIdentitiesMatch("Sun Aug 3 00:00:00 2026", "win32-powershell-ticks-v1:638000000000000000", "win32"), undefined);
 	assert.equal(processStartIdentitiesMatch("win32-powershell-ticks-v1:1", "win32-powershell-ticks-v1:2", "win32"), false);
+});
+
+test("process start identity falls back from absolute candidates to PATH and stops after success", async () => {
+	const commands = buildProcessStartIdentityCommands(123, "linux");
+	const attempts: string[] = [];
+	assert.equal(await resolveProcessStartIdentityFromCommands(commands, async (command) => {
+		attempts.push(command.file);
+		return command.file === "ps" ? "Sun Aug 3 00:00:00 2026" : undefined;
+	}), "Sun Aug 3 00:00:00 2026");
+	assert.deepEqual(attempts, ["/bin/ps", "/usr/bin/ps", "ps"]);
+
+	attempts.length = 0;
+	assert.equal(await resolveProcessStartIdentityFromCommands(commands, async (command) => {
+		attempts.push(command.file);
+		return command.file === "/bin/ps" ? "absolute-identity" : undefined;
+	}), "absolute-identity");
+	assert.deepEqual(attempts, ["/bin/ps"]);
+});
+
+test("process start identity fails closed when candidates are unavailable or PATH output is malformed", async () => {
+	const commands = buildProcessStartIdentityCommands(123, "linux");
+	assert.equal(await resolveProcessStartIdentityFromCommands(commands, async () => undefined), undefined);
+	assert.equal(normalizeProcessStartIdentity("  \r\n"), undefined);
+	assert.equal(normalizeProcessStartIdentity("first record\nsecond record"), undefined);
+	assert.equal(normalizeProcessStartIdentity("identity\0suffix"), undefined);
+
+	assert.equal(await resolveProcessStartIdentityFromCommands(commands, async (command) => {
+		if (command.file !== "ps") return undefined;
+		return await executeProcessStartIdentityCommand(command, (_file, _args, _options, callback) => {
+			callback(null, "first record\nsecond record\n");
+		});
+	}), undefined);
+});
+
+test("PATH process identity execution keeps the five-second timeout and treats timeout errors as unavailable", async () => {
+	const pathCommand = buildProcessStartIdentityCommands(123, "linux").at(-1);
+	assert.equal(pathCommand?.file, "ps");
+	let observedTimeout: number | undefined;
+	assert.equal(await executeProcessStartIdentityCommand(pathCommand!, (_file, _args, options, callback) => {
+		observedTimeout = options.timeout;
+		callback(Object.assign(new Error("timed out"), { code: "ETIMEDOUT" }), "Sun Aug 3 00:00:00 2026\n");
+	}), undefined);
+	assert.equal(observedTimeout, 5_000);
+	assert.equal(await executeProcessStartIdentityCommand(pathCommand!, () => {
+		throw new Error("ps is unavailable");
+	}), undefined);
 });
 
 test("Windows managed restore commit excludes PowerShell command-not-found wrappers", () => {


### PR DESCRIPTION
This falls back to using `PATH` to find `ps`, which patches the issue for some distros where `ps` is not in the hard-coded paths.

Fixes: #142 
