### PR TITLE
Reject bare Chromium no-sandbox arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Rejected bare `--no-sandbox` tokens with guidance to prefer a working Chromium sandbox or pass the launch switch through `--args` when required.
 - Preserved stdout chunk ordering while switching oversized subprocess output from memory to a spill file, preventing valid JSON envelopes from being reordered under fast chunk delivery.
 - Accepted both npm 11's array and npm 12's keyed-object `npm pack --json` result shapes in package verification.
 

--- a/docs/COMMAND_REFERENCE.md
+++ b/docs/COMMAND_REFERENCE.md
@@ -952,7 +952,7 @@ Browser default config is conservative: it adds agent guidance for signed-in/acc
 
 - `--executable-path <path>`: custom Chromium-compatible browser executable, such as Brave/Edge/Arc/Vivaldi when upstream can launch that binary. Environment: `AGENT_BROWSER_EXECUTABLE_PATH`.
 - `--extension <path>`: load browser extensions; repeatable. Environment: `AGENT_BROWSER_EXTENSIONS`.
-- `--args <args>`: browser launch args, comma or newline separated. Environment: `AGENT_BROWSER_ARGS`.
+- `--args <args>`: browser launch args, comma or newline separated. Chromium switches belong inside this value; a bare `--no-sandbox` token is rejected because upstream would ignore it. Prefer a working Chromium sandbox. If a host explicitly requires the workaround, use `{ args: ["--args", "--no-sandbox", "open", "https://example.com"], sessionMode: "fresh" }`. Environment: `AGENT_BROWSER_ARGS`.
 - `--user-agent <ua>`: custom user agent. Environment: `AGENT_BROWSER_USER_AGENT`.
 - `--proxy <server>`: proxy server URL. Environments: `AGENT_BROWSER_PROXY`, `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`.
 - `--proxy-bypass <hosts>`: proxy bypass hosts. Environments: `AGENT_BROWSER_PROXY_BYPASS`, `NO_PROXY`.

--- a/extensions/agent-browser/lib/runtime.ts
+++ b/extensions/agent-browser/lib/runtime.ts
@@ -764,6 +764,14 @@ function getUnsupportedInlineWaitDownloadError(args: string[]): string | undefin
 	return `agent-browser ${TARGET_AGENT_BROWSER_VERSION} does not support \`wait --download=<path>\`. Pass the optional path as a separate argument: \`wait --download <path>\` (or \`wait -d <path>\`).`;
 }
 
+function getBareNoSandboxValidationError(args: string[]): string | undefined {
+	const browserArgIndexes = new Set(
+		scanUpstreamGlobalFlagOccurrences(args, "--args").map(({ index }) => index + 1),
+	);
+	if (!args.some((token, index) => token === "--no-sandbox" && !browserArgIndexes.has(index))) return undefined;
+	return "`--no-sandbox` is a Chromium launch argument, not an agent-browser flag, so upstream would ignore this token. Prefer a working Chromium sandbox. If the host requires this workaround, pass it through `--args` and start a fresh session: { args: [\"--args\", \"--no-sandbox\", \"open\", \"https://example.com\"], sessionMode: \"fresh\" }.";
+}
+
 export function validateToolArgs(args: string[]): string | undefined {
 	if (args.length === 0) {
 		return "`args` must contain at least one agent-browser command token.";
@@ -779,7 +787,7 @@ export function validateToolArgs(args: string[]): string | undefined {
 		return "Do not pass `--session-mode` in args. Use the top-level agent_browser `sessionMode` field instead, for example { args: [\"--profile\", \"Default\", \"open\", \"https://example.com\"], sessionMode: \"fresh\" }.";
 	}
 
-	return getBareMcpValidationError(args) ?? getSingleKeyCommandValidationError(args) ?? getUnsupportedInlineWaitDownloadError(args);
+	return getBareNoSandboxValidationError(args) ?? getBareMcpValidationError(args) ?? getSingleKeyCommandValidationError(args) ?? getUnsupportedInlineWaitDownloadError(args);
 }
 
 function getInvalidValueFlagDetails(args: string[]): InvalidValueFlagDetails | undefined {

--- a/test/agent-browser.extension-validation.test.ts
+++ b/test/agent-browser.extension-validation.test.ts
@@ -339,6 +339,26 @@ test("agentBrowserExtension rejects unsupported extra press/key args before upst
 	}
 });
 
+test("agentBrowserExtension rejects bare Chromium no-sandbox flags before upstream spawn", { concurrency: false }, async () => {
+	const tempDir = await mkdtemp(join(tmpdir(), "pi-agent-browser-no-sandbox-validation-"));
+	try {
+		const harness = createExtensionHarness({ cwd: tempDir });
+		await runExtensionEvent(harness.handlers, "session_start", { reason: "new" }, harness.ctx);
+
+		const result = await executeRegisteredTool(harness.tool, harness.ctx, {
+			args: ["open", "https://example.test/", "--no-sandbox"],
+			sessionMode: "fresh",
+		});
+		assert.equal(result.isError, true);
+		assert.equal(result.details?.failureCategory, "validation-error");
+		assert.match(result.content[0]?.text ?? "", /Chromium launch argument/);
+		assert.match(result.content[0]?.text ?? "", /\["--args", "--no-sandbox", "open"/);
+		assert.equal(result.details?.validationError, result.content[0]?.text);
+	} finally {
+		await rm(tempDir, { force: true, recursive: true });
+	}
+});
+
 test("agentBrowserExtension rejects duplicate explicit artifact destinations inside one batch", { concurrency: false }, async () => {
 	const tempDir = await mkdtemp(join(tmpdir(), "pi-agent-browser-duplicate-artifact-"));
 	try {

--- a/test/agent-browser.runtime.test.ts
+++ b/test/agent-browser.runtime.test.ts
@@ -1270,6 +1270,19 @@ test("validateToolArgs rejects one-shot mcp server calls but preserves --help/-h
 	assert.match(validateToolArgs(["mcp", "help"]) ?? "", /external MCP clients/);
 });
 
+test("validateToolArgs rejects bare Chromium no-sandbox flags", () => {
+	for (const args of [
+		["--no-sandbox", "open", "https://example.com"],
+		["open", "https://example.com", "--no-sandbox"],
+	] as const) {
+		const error = validateToolArgs([...args]) ?? "";
+		assert.match(error, /Chromium launch argument/);
+		assert.match(error, /\["--args", "--no-sandbox", "open"/);
+	}
+	assert.equal(validateToolArgs(["--args", "--no-sandbox", "open", "https://example.com"]), undefined);
+	assert.equal(validateToolArgs(["--args", "--disable-gpu,--no-sandbox", "open", "https://example.com"]), undefined);
+});
+
 test("buildExecutionPlan still injects managed sessions for browser-backed state and auth commands", () => {
 	for (const args of [["state", "save", "./auth.json"], ["state", "load", "./auth.json"], ["auth", "login", "demo"]] as const) {
 		const plan = buildExecutionPlan([...args], {
@@ -1992,4 +2005,3 @@ test("redactSensitiveValue masks obvious secret-bearing object keys", () => {
 		},
 	);
 });
-


### PR DESCRIPTION
## Summary

- reject bare `--no-sandbox` tokens that agent-browser silently ignores
- point callers to the effective `--args` form while preferring a working Chromium sandbox
- cover runtime and extension-level validation and document the launch-argument shape

## Context

A native tool retry placed `--no-sandbox` after the `open` URL. Upstream treated it as an unused token, repeated the original launch failure, and left the caller without actionable validation.

## Verification

- `npx tsx --test --test-concurrency=1 test/agent-browser.runtime.test.ts test/agent-browser.extension-validation.test.ts` (93 passed)
- `npm run typecheck`
- `npm run docs`

`npm run verify -- pre-pr` reaches unrelated managed-restore failures on this XFS host. The same restore-key test fails on clean `origin/main`; the changed focused suites pass.