### PR TITLE
fix(windows): preserve empty agent-browser argv values

### DIFF
--- a/extensions/agent-browser/lib/process.ts
+++ b/extensions/agent-browser/lib/process.ts
@@ -1,5 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { lstat, mkdir, readdir, readlink, stat } from "node:fs/promises";
 import { dirname, isAbsolute, join } from "node:path";
 import { env as processEnv, platform as processPlatform } from "node:process";
@@ -91,6 +92,24 @@ function quoteWindowsPowerShellArg(value: string): string {
 	return `'${value.replace(/'/g, "''")}'`;
 }
 
+/** Prefer the native binary so Windows does not round-trip argv through PowerShell 5.1. */
+export function resolveWindowsAgentBrowserNativeBinary(env: NodeJS.ProcessEnv = processEnv): string | undefined {
+	const pathEntries = env.PATH?.split(";").filter(Boolean);
+	if (pathEntries) {
+		for (const pathEntry of pathEntries) {
+			if (!existsSync(join(pathEntry, "agent-browser.cmd"))) continue;
+			const candidate = join(pathEntry, "node_modules", "agent-browser", "bin", "agent-browser-win32-x64.exe");
+			return existsSync(candidate) ? candidate : undefined;
+		}
+		return undefined;
+	}
+	const appData = env.APPDATA;
+	if (!appData) return undefined;
+	const npmBin = join(appData, "npm");
+	const candidate = join(npmBin, "node_modules", "agent-browser", "bin", "agent-browser-win32-x64.exe");
+	return existsSync(candidate) ? candidate : undefined;
+}
+
 /** Exported for unit tests that lock Windows launcher argv ordering. */
 export function reorderWindowsLeadingGlobalArgs(args: string[]): string[] {
 	const leadingGlobals: string[] = [];
@@ -152,10 +171,12 @@ export function prepareAgentBrowserSpawnArgs(args: string[], wrapperCompatibilit
 	return ["--args", `--user-agent=${wrapperCompatibilityUserAgent.replaceAll(/[\r\n,]/g, "")}`, ...args];
 }
 
-export function buildAgentBrowserSpawnCommand(args: string[], platform: NodeJS.Platform = processPlatform): { command: string; args: string[] } {
+export function buildAgentBrowserSpawnCommand(args: string[], platform: NodeJS.Platform = processPlatform, env: NodeJS.ProcessEnv = processEnv): { command: string; args: string[] } {
 	if (platform !== "win32") {
 		return { command: "agent-browser", args };
 	}
+	const nativeBinary = resolveWindowsAgentBrowserNativeBinary(env);
+	if (nativeBinary) return { command: nativeBinary, args };
 	const invocationArgs = reorderWindowsLeadingGlobalArgs(args).map(quoteWindowsPowerShellArg).join(" ");
 	const commandLine = [
 		"$agentBrowser = Get-Command agent-browser.cmd -ErrorAction SilentlyContinue;",
@@ -662,7 +683,7 @@ export async function runAgentBrowserProcess(options: {
 			resolve({ aborted: false, agentBrowserStarted: false, exitCode: 1, spawnError: new Error(spawnPolicyError), stderr: "", stdout: "", timedOut: false });
 			return;
 		}
-		const spawnCommand = buildAgentBrowserSpawnCommand(prepareAgentBrowserSpawnArgs(args, ownedManagedSessionCompatibilityEnv.AGENT_BROWSER_USER_AGENT, preserveAttachedBrowserSession));
+		const spawnCommand = buildAgentBrowserSpawnCommand(prepareAgentBrowserSpawnArgs(args, ownedManagedSessionCompatibilityEnv.AGENT_BROWSER_USER_AGENT, preserveAttachedBrowserSession), processPlatform, childEnv);
 		const child = spawn(spawnCommand.command, spawnCommand.args, {
 			cwd,
 			env: childEnv,

--- a/test/agent-browser.process.test.ts
+++ b/test/agent-browser.process.test.ts
@@ -35,6 +35,7 @@ import {
 	isWindowsAgentBrowserCommandMissing,
 	prepareAgentBrowserSpawnArgs,
 	reorderWindowsLeadingGlobalArgs,
+	resolveWindowsAgentBrowserNativeBinary,
 	resolveSpawnedChildExitCode,
 	shouldCommitManagedRestoreAfterWindowsProcess,
 	runAgentBrowserProcess,
@@ -191,12 +192,9 @@ test("prepareAgentBrowserSpawnArgs preserves caller launch controls", () => {
 
 test("runAgentBrowserProcess passes upstream browser configuration and file access through", { concurrency: false }, async () => {
 	const tempDir = await mkdtemp(join(tmpdir(), "pi-agent-browser-raw-args-"));
-	const binaryPath = join(tempDir, "agent-browser");
 	const basePath = process.env.PATH ?? "";
-	await writeFile(binaryPath, `#!/usr/bin/env node
-const config = process.env.AGENT_BROWSER_CONFIG;
-process.stdout.write(JSON.stringify({ success: true, data: { allowFileAccessEnv: process.env.AGENT_BROWSER_ALLOW_FILE_ACCESS ?? null, args: process.argv.slice(2), config, configContent: config ? require("node:fs").readFileSync(config, "utf8") : null, envArgs: process.env.AGENT_BROWSER_ARGS ?? null } }));\n`, "utf8");
-	await chmod(binaryPath, 0o755);
+	await writeFakeAgentBrowserBinary(tempDir, `const config = process.env.AGENT_BROWSER_CONFIG;
+process.stdout.write(JSON.stringify({ success: true, data: { allowFileAccessEnv: process.env.AGENT_BROWSER_ALLOW_FILE_ACCESS ?? null, args: process.argv.slice(2), config, configContent: config ? require("node:fs").readFileSync(config, "utf8") : null, envArgs: process.env.AGENT_BROWSER_ARGS ?? null } }));\n`);
 	try {
 		const configPath = join(tempDir, "agent-browser.json");
 		await writeFile(configPath, "{\"headed\":true}\n");
@@ -222,24 +220,40 @@ process.stdout.write(JSON.stringify({ success: true, data: { allowFileAccessEnv:
 			assert.deepEqual(data.args, ["--allow-file-access", "false", "get", "url"]);
 		});
 	} finally {
-		await rm(tempDir, { force: true, recursive: true });
+		await rm(tempDir, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 });
 	}
 });
 
 
 test("buildAgentBrowserSpawnCommand uses the npm cmd shim on Windows", () => {
 	assert.deepEqual(
-		buildAgentBrowserSpawnCommand(["--json", "--session", "managed", "open", "https://example.com"], "win32"),
+		buildAgentBrowserSpawnCommand(["--json", "--session", "managed", "open", "https://example.com"], "win32", {}),
 		{
 			command: "powershell.exe",
 			args: ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "$agentBrowser = Get-Command agent-browser.cmd -ErrorAction SilentlyContinue; if (-not $agentBrowser) { [Console]::Error.WriteLine('PI_AGENT_BROWSER_COMMAND_NOT_FOUND:agent-browser.cmd'); exit 127 }; & $agentBrowser.Source 'open' '--json' '--session' 'managed' 'https://example.com'"],
 		},
 	);
 	assert.match(
-		buildAgentBrowserSpawnCommand(["--json", "--session", "managed", "webmcp", "invoke", "search", "--params", `{"query":"Mitch's browser"}`], "win32").args.at(-1) ?? "",
+		buildAgentBrowserSpawnCommand(["--json", "--session", "managed", "webmcp", "invoke", "search", "--params", `{"query":"Mitch's browser"}`], "win32", {}).args.at(-1) ?? "",
 		/& \$agentBrowser\.Source 'webmcp' 'invoke' '--json' '--session' 'managed' 'search' '--params' '\{"query":"Mitch''s browser"\}'$/,
 	);
 	assert.deepEqual(buildAgentBrowserSpawnCommand(["--version"], "darwin"), { command: "agent-browser", args: ["--version"] });
+});
+
+test("buildAgentBrowserSpawnCommand uses the shipped Windows binary to preserve empty argv values", async () => {
+	const appData = await mkdtemp(join(tmpdir(), "pi-agent-browser-native-bin-"));
+	const nativeBinary = join(appData, "npm", "node_modules", "agent-browser", "bin", "agent-browser-win32-x64.exe");
+	try {
+		await mkdir(dirname(nativeBinary), { recursive: true });
+		await writeFile(nativeBinary, "native-test-binary");
+		const env = { PATH: join(appData, "npm") };
+		await writeFile(join(appData, "npm", "agent-browser.cmd"), "shim");
+		const args = ["--json", "--namespace", "", "--args", "", "--allow-file-access", "false", "--session", "managed", "session", "info"];
+		assert.equal(resolveWindowsAgentBrowserNativeBinary(env), nativeBinary);
+		assert.deepEqual(buildAgentBrowserSpawnCommand(args, "win32", env), { command: nativeBinary, args });
+	} finally {
+		await rm(appData, { force: true, recursive: true });
+	}
 });
 
 test("process start identity commands prefer system paths before PATH and keep native PowerShell on Windows", async () => {
@@ -1374,4 +1388,3 @@ process.stdout.write(JSON.stringify(envelope));`,
 		await rm(tempDir, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 });
 	}
 });
-


### PR DESCRIPTION
Fixes #141

PowerShell 5.1 and the agent-browser.cmd shim can drop empty-string argv values. That breaks managed-session policy probes that pass an empty --namespace or --args value.

This change resolves the native agent-browser-win32-x64.exe beside the first agent-browser.cmd found in the effective child PATH and passes argv directly to it. The existing PowerShell launcher remains the fallback when the native binary is unavailable. The Windows test fixture now uses a .cmd shim so tests do not run the real browser or open tmp/page.html.

Verified:
- npm run typecheck
- npm run build
- Focused Windows launcher tests: 2 passed
- Native Windows PowerShell 5.1 repro with pi-agent-browser-native 0.6.7, Pi 0.85.1, Node v24.18.1, and agent-browser 0.34.0
- Empty --namespace and --args values reached the native executable and session info returned success

The installed upstream agent-browser is 0.34.0, below this repository’s supported minimum of 0.35.0. The native repro passed against that installed version; a follow-up retest with 0.35.0 or newer is still advisable.