### PR TITLE
docs: restart Pi after package updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Then install this Pi package:
 pi install npm:pi-agent-browser-native
 ```
 
+After updating `pi-agent-browser-native`, fully quit and restart Pi before using the updated tools. `/reload` can retain previously loaded compiled JavaScript even after `dist/` is rebuilt, so it is not a reliable way to pick up package updates.
+
 Start Pi and ask for a browser action:
 
 ```text

--- a/docs/COMMAND_REFERENCE.md
+++ b/docs/COMMAND_REFERENCE.md
@@ -14,6 +14,8 @@ Provide a local, repo-readable command reference for the native `agent_browser` 
 
 This project intentionally blocks normal `agent-browser` bash usage in most agent sessions, so the agent still needs an accessible local equivalent of the upstream command surface. This document is the durable reference the agent can read inside the repository without calling the binary directly.
 
+After updating `pi-agent-browser-native`, fully quit and restart Pi before using the updated tools. `/reload` can retain previously loaded compiled JavaScript even after `dist/` is rebuilt, so it is not a reliable way to pick up package updates.
+
 ## Upstream baseline
 
 <!-- agent-browser-capability-baseline:start upstream-baseline -->

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -316,6 +316,8 @@ Recommended configured-source lifecycle follow-up:
 
 ## Post-publish install validation
 
+After updating `pi-agent-browser-native`, fully quit and restart Pi before using the updated tools. `/reload` can retain previously loaded compiled JavaScript even after `dist/` is rebuilt, so it is not a reliable way to pick up package updates.
+
 After publishing a release, validate the package-first path in isolation. `npm run verify -- release` includes the deterministic fake-binary packaged execution gate and the pre-publish Crabbox platform matrix, but it does not replace a real-browser installed-package smoke against the published npm package:
 
 ```bash


### PR DESCRIPTION
Refs #129.

Adds the approved two-sentence package-update restart warning to README, release validation, and the command reference. Existing reload/session-continuity guidance stays unchanged. No runtime, version, or dependency changes; optional cache-busting and upstream reporting are outside this docs-only scope.

Validation: `npm run docs -- command-reference check`, `git diff --check`, and exact paragraph/anchor checks pass: three files, one identical paragraph each, outside generated blocks, with all other content preserved.

The cautious **can retain** wording reuses the official Pi 0.85.1 SDK native-ESM proof on native Mac (Node 24.20.0) and Ubuntu (Node 24.16.0): v1 → v1 after `session.reload()` → v2 after restart, factory registrations 1 → 2 → 1, and native function identity confirmed. This tests the SDK reload path, not the bundled CLI/TUI or a full Browser-package update.
