### PR TITLE
fix: expose native browser session status to the model

### DIFF
--- a/docs/TOOL_CONTRACT.md
+++ b/docs/TOOL_CONTRACT.md
@@ -961,6 +961,8 @@ If `agent-browser` is not on `PATH`, fail with a message that:
 
 ## Session behavior
 
+`session info` text preserves native `active`, PID, namespace/socket directory, version, and returned runtime identity/status fields, including null values and redacted runtime errors. `active` describes daemon inventory, not browser readiness; check `runtime.browserLaunched` separately. An active daemon with `runtime: null` has unavailable runtime information, not proof of a reusable browser. Name-only `session` responses identify the selected session without proving liveness. Fields upstream does not return (including the browser profile in 0.37.1) remain unknown; restore check URLs, text, and code are omitted from the status text.
+
 - maintain one extension-managed active session per `pi` session for the common path
 - derive the base implicit session name from the official `pi` session id plus a cwd hash so same-named checkouts do not collide
 - respect explicit upstream `--session` and configured native session/namespace defaults with minimal interference; per-call `--config` reaches helpers without changing native precedence

--- a/extensions/agent-browser/lib/results/presentation/diagnostics.ts
+++ b/extensions/agent-browser/lib/results/presentation/diagnostics.ts
@@ -296,6 +296,18 @@ function formatSessionText(data: Record<string, unknown>): string | undefined {
 			})
 			.join("\n");
 	}
+	if (typeof data.active === "boolean") {
+		const runtime = data.runtime;
+		return stringifyModelFacing({
+			...Object.fromEntries(["session", "namespace", "socketDir", "active", "pid", "version", "runtimeError"].map((key) => [key, data[key]])),
+			// Native runtime also includes restore check URLs, text and code; show status/identity only.
+			runtime: isRecord(runtime) ? Object.fromEntries([
+				"session", "namespace", "socketDir", "backgroundPid", "browserLaunched", "pageCount", "engine", "launchHash",
+				"compatibilityStatus", "restoreKey", "restoreStatus", "restoreLoadedPath", "restoreValidationPending",
+				"restoreSave", "saveStatus", "restoreSavedPath",
+			].map((key) => [key, runtime[key]])) : runtime,
+		});
+	}
 	const session = getStringField(data, "session");
 	return session ? `Current session: ${redactModelFacingText(session)}` : undefined;
 }

--- a/test/agent-browser.extension-errors-artifacts.test.ts
+++ b/test/agent-browser.extension-errors-artifacts.test.ts
@@ -1336,9 +1336,7 @@ if (args.includes("session") && args.includes("info")) {
 test("agentBrowserExtension reports managed-session outcomes after failed fresh launches", { concurrency: false }, async (context) => {
 	const shortTempRoot = dirname(getAgentBrowserSocketDir() ?? join(tmpdir(), "piab"));
 	const tempDir = await mkdtemp(join(shortTempRoot, "a-"));
-	const socketDir = join(shortTempRoot, `p${(process.pid % 36).toString(36)}`);
-	await rm(socketDir, { force: true, recursive: true });
-	await mkdir(socketDir, { mode: 0o700 });
+	const socketDir = await mkdtemp(join(process.platform === "win32" ? tmpdir() : "/tmp", "p-"));
 	context.after(async () => {
 		await rm(socketDir, { force: true, recursive: true });
 	});

--- a/test/agent-browser.extension-passthrough-validation.test.ts
+++ b/test/agent-browser.extension-passthrough-validation.test.ts
@@ -7,9 +7,9 @@
  */
 
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, dirname, join } from "node:path";
 import test from "node:test";
 
 import {
@@ -30,6 +30,55 @@ const stripWrapperPrefix = (args: string[]) => {
 	if (stripped[0] === "--session") stripped.splice(0, 2);
 	return stripped;
 };
+
+test("agentBrowserExtension exposes native session-info facts in model-visible content", { concurrency: false }, async () => {
+	const root = await mkdtemp(join(tmpdir(), "piab-si-"));
+	const home = join(root, "home");
+	const temp = join(root, "tmp");
+	const sockets = join(root, "s");
+	const logPath = join(root, "calls.jsonl");
+	const dataPath = join(root, "data.json");
+	await Promise.all([home, temp, sockets].map((path) => mkdir(path, { mode: 0o700 })));
+	await writeFakeAgentBrowserBinary(root, `const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({ args }) + "\\n");
+if (!args.includes("session") || !args.includes("info")) throw new Error("Unexpected browser command");
+process.stdout.write(JSON.stringify({ success: true, data: JSON.parse(fs.readFileSync(${JSON.stringify(dataPath)}, "utf8")) }));`);
+	const clearedEnv = Object.fromEntries(Object.keys(process.env)
+		.filter((key) => /^(?:PI_)?AGENT_BROWSER_/.test(key)).map((key) => [key, undefined]));
+	try {
+		await withPatchedEnv({ ...clearedEnv, HOME: home, USERPROFILE: home, TMPDIR: temp, TMP: temp, TEMP: temp,
+			PATH: `${root}${delimiter}${dirname(process.execPath)}`, PI_AGENT_BROWSER_SOCKET_DIR: sockets,
+			AGENT_BROWSER_SOCKET_DIR: sockets, AGENT_BROWSER_NAMESPACE: "fixture",
+			PI_AGENT_BROWSER_TEST_CUSTOM_SESSION_INFO: "1",
+		}, async () => {
+			const harness = createExtensionHarness({ cwd: root });
+			await runExtensionEvent(harness.handlers, "session_start", { reason: "new" }, harness.ctx);
+			try {
+				for (const status of [
+					{ active: false, pid: null, version: null, runtime: null, runtimeError: null },
+					{ active: true, pid: 1234, version: "0.37.1", runtime: { browserLaunched: true, engine: "chromium", launchHash: "launch-identity", restoreKey: "shared-auth" }, runtimeError: null },
+					{ active: true, pid: 1234, version: "0.37.1", runtime: null, runtimeError: "Runtime info unavailable" },
+				]) {
+					const data = { session: "fixture", namespace: "fixture", socketDir: sockets, ...status };
+					await writeFile(dataPath, JSON.stringify(data));
+					const result = await executeRegisteredTool(harness.tool, harness.ctx, { args: ["--session", "fixture", "session", "info"] });
+					assert.equal(result.isError, false);
+					assert.deepEqual(JSON.parse(result.content[0]?.text ?? ""), data);
+					assert.deepEqual(result.details?.data, data);
+				}
+				await writeFile(dataPath, JSON.stringify({ session: "fixture" }));
+				const legacy = await executeRegisteredTool(harness.tool, harness.ctx, { args: ["--session", "fixture", "session", "info"] });
+				assert.equal(legacy.content[0]?.text, "Current session: fixture");
+				assert.equal((await readInvocationLog(logPath)).length, 4);
+			} finally {
+				await runExtensionEvent(harness.handlers, "session_shutdown", {}, harness.ctx);
+			}
+		});
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
 
 test("agentBrowserExtension keeps successful plain-text inspection stateless and machine-readable", { concurrency: false }, async () => {
 	const tempDir = await mkdtemp(join(tmpdir(), "pi-agent-browser-test-"));

--- a/test/agent-browser.presentation-diagnostics.test.ts
+++ b/test/agent-browser.presentation-diagnostics.test.ts
@@ -186,6 +186,51 @@ test("buildToolPresentation formats session status and session list", async () =
 	assert.match((list.content[0] as { text: string }).text, /name=work/);
 });
 
+test("buildToolPresentation exposes native session-info liveness and runtime identity", async () => {
+	const identity = { session: "shared", namespace: null, socketDir: "/tmp/isolated-sockets" };
+	for (const status of [
+		{ active: false, pid: null, version: null, runtime: null, runtimeError: null },
+		{ active: true, pid: 1234, version: "0.37.1", runtime: null, runtimeError: null },
+		{ active: true, pid: 1234, version: "0.37.1", runtime: null, runtimeError: "Runtime info unavailable" },
+		{ active: true, pid: 1234, version: "0.37.1", runtime: {
+			session: "shared", namespace: null, socketDir: identity.socketDir, backgroundPid: 1234,
+			browserLaunched: false, pageCount: 0, engine: "chromium", launchHash: null,
+			compatibilityStatus: "current", restoreKey: null, restoreStatus: "disabled",
+			restoreValidationPending: false, restoreSave: false, saveStatus: "disabled",
+		}, runtimeError: null },
+	]) {
+		const data = { ...identity, ...status };
+		const result = await buildToolPresentation({
+			commandInfo: { command: "session", subcommand: "info" },
+			cwd: process.cwd(), envelope: { success: true, data },
+		});
+		assert.deepEqual(JSON.parse((result.content[0] as { text: string }).text), data);
+	}
+});
+
+test("buildToolPresentation limits native session-info text to redacted status metadata", async () => {
+	const runtime = {
+		browserLaunched: true, pageCount: 2, engine: "chromium", launchHash: "launch-identity",
+		restoreKey: "shared-auth", restoreStatus: "loaded", restoreLoadedPath: "/tmp/shared-auth.json",
+		saveStatus: "saved", restoreSavedPath: "/tmp/shared-auth.json",
+	};
+	const result = await buildToolPresentation({
+		commandInfo: { command: "session", subcommand: "info" }, cwd: process.cwd(),
+		envelope: { success: true, data: {
+			session: "shared", namespace: "team", active: true, pid: 1234,
+			runtimeError: "Authorization: Bearer runtime-secret",
+			runtime: { ...runtime, restoreCheckUrl: "https://private.test/path", restoreCheckText: "private-text",
+				restoreCheckFn: "private-function", restoreStatusDetail: "private-detail",
+				password: "private-password", cdpUrl: "ws://private.test/control" },
+		} },
+	});
+	const text = (result.content[0] as { text: string }).text;
+	const visible = JSON.parse(text);
+	assert.deepEqual(visible.runtime, runtime);
+	assert.match(visible.runtimeError, /REDACTED/);
+	assert.doesNotMatch(text, /runtime-secret|private|profile/);
+});
+
 test("buildToolPresentation formats Chrome profile arrays", async () => {
 	const presentation = await buildToolPresentation({
 		commandInfo: { command: "profiles" },

--- a/test/agent-browser.shared-defaults.test.ts
+++ b/test/agent-browser.shared-defaults.test.ts
@@ -14,7 +14,7 @@ const clearedBrowserEnv = Object.fromEntries(Object.keys(process.env)
 	.map((name) => [name, undefined]));
 
 test("native environment defaults share caller ownership across Pi sessions and helpers", async () => {
-	const root = await mkdtemp(join(tmpdir(), "piab-shared-"));
+	const root = await mkdtemp(join(process.platform === "win32" ? tmpdir() : "/tmp", "pbs-shared-"));
 	const log = join(root, "calls.jsonl");
 	await writeFakeAgentBrowserBinary(root, `
 const args = process.argv.slice(2);
@@ -23,7 +23,7 @@ const data = args.includes("snapshot") ? { snapshot: "- button \\"Continue\\" [r
 console.log(JSON.stringify({ success: true, data }));
 `);
 	try {
-		await withPatchedEnv({ ...clearedBrowserEnv, HOME: root, USERPROFILE: root, PATH: `${root}${delimiter}${process.env.PATH}`, AGENT_BROWSER_SESSION: "shared", AGENT_BROWSER_NAMESPACE: "Team Work", PI_AGENT_BROWSER_MANAGED_SESSION_RESTORE: "0" }, async () => {
+		await withPatchedEnv({ ...clearedBrowserEnv, HOME: root, USERPROFILE: root, PI_AGENT_BROWSER_SOCKET_DIR: join(root, "s"), PATH: `${root}${delimiter}${process.env.PATH}`, AGENT_BROWSER_SESSION: "shared", AGENT_BROWSER_NAMESPACE: "Team Work", PI_AGENT_BROWSER_MANAGED_SESSION_RESTORE: "0" }, async () => {
 			const one = createExtensionHarness({ cwd: root, sessionId: "pi-one" });
 			const two = createExtensionHarness({ cwd: root, sessionId: "pi-two" });
 			for (const harness of [one, two]) {
@@ -50,7 +50,7 @@ console.log(JSON.stringify({ success: true, data }));
 });
 
 test("unconfigured implicit sessions retain ownership and idle cleanup", async () => {
-	const root = await mkdtemp(join(tmpdir(), "piab-owned-"));
+	const root = await mkdtemp(join(process.platform === "win32" ? tmpdir() : "/tmp", "pbs-owned-"));
 	const log = join(root, "calls.jsonl");
 	await writeFakeAgentBrowserBinary(root, `
 const args = process.argv.slice(2);
@@ -58,7 +58,7 @@ require("node:fs").appendFileSync(${JSON.stringify(log)}, JSON.stringify({ args,
 console.log(JSON.stringify({ success: true, data: { title: "Fixture", url: "about:blank" } }));
 `);
 	try {
-		await withPatchedEnv({ ...clearedBrowserEnv, HOME: root, USERPROFILE: root, PATH: `${root}${delimiter}${process.env.PATH}`, PI_AGENT_BROWSER_MANAGED_SESSION_RESTORE: "0" }, async () => {
+		await withPatchedEnv({ ...clearedBrowserEnv, HOME: root, USERPROFILE: root, PI_AGENT_BROWSER_SOCKET_DIR: join(root, "s"), PATH: `${root}${delimiter}${process.env.PATH}`, PI_AGENT_BROWSER_MANAGED_SESSION_RESTORE: "0" }, async () => {
 			const harness = createExtensionHarness({ cwd: root });
 			const result = await executeRegisteredTool(harness.tool, harness.ctx, { args: ["open", "about:blank"] });
 			assert.equal(result.isError, false, result.content[0]?.text);
@@ -75,7 +75,7 @@ console.log(JSON.stringify({ success: true, data: { title: "Fixture", url: "abou
 });
 
 test("real native config identity follows file, environment and argv precedence", { skip: process.env.PI_AGENT_BROWSER_REAL_UPSTREAM !== "1" }, async () => {
-	const root = await mkdtemp(join(tmpdir(), "piab-config-"));
+	const root = await mkdtemp(join(process.platform === "win32" ? tmpdir() : "/tmp", "pbs-config-"));
 	await mkdir(join(root, ".agent-browser"));
 	const global = join(root, ".agent-browser", "config.json");
 	const project = join(root, "agent-browser.json");
@@ -84,7 +84,7 @@ test("real native config identity follows file, environment and argv precedence"
 	await writeFile(project, JSON.stringify({ session: "project" }));
 	await writeFile(explicit, JSON.stringify({ session: "default", namespace: "" }));
 	try {
-		await withPatchedEnv({ ...clearedBrowserEnv, HOME: root, USERPROFILE: root }, async () => {
+		await withPatchedEnv({ ...clearedBrowserEnv, HOME: root, USERPROFILE: root, PI_AGENT_BROWSER_SOCKET_DIR: join(root, "s") }, async () => {
 			const harness = createExtensionHarness({ cwd: root });
 			const inspect = async (args: string[], session: string, namespace?: string) => {
 				const result = await executeRegisteredTool(harness.tool, harness.ctx, { args: [...args, "session"] });


### PR DESCRIPTION
## Summary

Native `session info` returned daemon activity, PID and runtime information in tool details, but the model-visible text collapsed it to only `Current session: <name>`. Agents could miss an inactive session and choose the wrong follow-up.

- Preserve native `active`, PID, version, namespace/socket directory and returned runtime identity/status in the existing redacted formatter.
- Keep null values and missing fields distinct. Name-only session responses and other diagnostics retain their existing output.
- Show selected status metadata rather than private restore-check URLs, text or code. Keep credential redaction.
- Isolate existing test fixtures with short, private socket directories. Remove a PID-derived global test directory and keep cleanup limited to fixture-owned paths. All original assertions remain unchanged.

`active` describes daemon inventory, **not browser readiness**; `runtime.browserLaunched` is separate. An active daemon with unavailable runtime information is not proof of a reusable browser. Native 0.37.1 does not return browser profile identity, so it remains unknown.

This builds on merged #171. The runtime change remains presentation-only: no lifecycle, idle-timeout, config, state, tool schema or API changes. The follow-up commits change test setup only.

## Verification

On clean commit `e76863aeb002b82791d8deae059a97a800cdaa04` (tree `adb623a7de805b153573a8948e202fde08dda0ce`):

- **Complete default test suite: 1065 tests; 1050 passed, 0 failed, 15 expected skips.**
- `npm run build`, `npm run typecheck` and `npm run docs` passed.
- Tests used private HOME, Pi, temporary and socket paths with native-browser opt-ins off. OS restrictions denied shared browser/profile paths and the old global short socket paths.
- The existing fixture tests failed before their repair with shared-path access denied, then passed after the repair. The reproduced Unix socket-length failure was fixed using short private roots; no assertions were weakened.
- Exact formatter regressions were RED against the pre-fix implementation (**3 failures**) and GREEN with the fix (**3 passes**); test hashes were unchanged. The earlier clean affected-suite run passed **138/138**.
- The pre-commit checkout-only Pi **0.85.1** smoke on `b2d740d` remains applicable: the entire runtime source tree and compiled entrypoint/formatter hashes are unchanged by the fixture-only commits. One real-model native-tool call against native **0.37.1** displayed `active: false` and null PID/version/runtime/error. The model read those values and reported no proof of a reusable browser or profile. Native output and model-visible content matched exactly.
- That Pi smoke used a new isolated session, private HOME/temp/socket namespace and an exact-command whitelist. Native process forks, networking and shared-socket access were denied. No browser was launched; transcripts and source/environment receipts are preserved.

## Limits

The 15 skips comprise 13 real-upstream checks, one opt-in isolated-namespace check and one ownership check requiring uid 0. Live upstream help-drift sampling and the release/platform matrix were not run in this fixture-only follow-up.

No live installation, existing Pi restart, working-browser/profile change or global configuration cutover is included. This PR does not prevent browser exits or establish live-browser readiness.
